### PR TITLE
fix(openclaw): upgrade auth to BitRouter v0.6.1 web3/SOL_EDDSA keypair format

### DIFF
--- a/openclaw/package.json
+++ b/openclaw/package.json
@@ -33,7 +33,8 @@
     "node": ">=18"
   },
   "openclaw": {
-    "id": "bitrouter"
+    "id": "bitrouter",
+    "extensions": ["./dist/index.js"]
   },
   "license": "MIT",
   "repository": {

--- a/openclaw/src/auth.ts
+++ b/openclaw/src/auth.ts
@@ -1,21 +1,33 @@
 /**
  * Ed25519 keypair generation and JWT minting for BitRouter auth.
  *
- * BitRouter authenticates API requests via EdDSA-signed JWTs. This module
- * generates an Ed25519 keypair in BitRouter's key format and mints JWTs
- * that the plugin uses to authenticate with the local BitRouter instance.
+ * BitRouter v0.6.1 switched to a "web3" keypair format (Solana-compatible
+ * Ed25519) and SOL_EDDSA JWT signing.
  *
- * Key format (from bitrouter-core/src/jwt/keys.rs):
- *   master.json: { "algorithm": "eddsa", "secret_key": "<base64url(seed+pubkey)>" }
- *   The 64-byte secret is 32-byte seed + 32-byte public key, base64url-encoded.
+ * Key format (bitrouter v0.6.1):
+ *   master.json: { "algorithm": "web3", "seed": "<base64url(32-byte seed)>" }
+ *   The 32-byte seed is used directly with Node.js Ed25519 (PKCS8 DER wrapping).
+ *   The public key is base58-encoded to form the Solana address.
  *
- * JWT format (from bitrouter-core/src/jwt/token.rs):
- *   base64url(header).base64url(claims).base64url(signature), no padding.
+ * JWT format (bitrouter v0.6.1):
+ *   header: { alg: "SOL_EDDSA", typ: "JWT" }
+ *   claims: { iss: "solana:<chain-id>:<base58-pubkey>", chain: "solana:<chain-id>", scope, ... }
+ *   signature: Ed25519 over "base64url(header).base64url(claims)"
+ *
+ * Solana mainnet chain ID: 5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp
  */
 
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+/** Solana mainnet genesis hash (chain identifier used in JWT iss). */
+const SOLANA_CHAIN_ID = "5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp";
+
+/** PKCS8 DER prefix for a bare Ed25519 private key seed (RFC 8410). */
+const PKCS8_ED25519_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
 
 // ── Base64url helpers ─────────────────────────────────────────────────
 
@@ -27,35 +39,60 @@ function base64urlDecode(str: string): Buffer {
   return Buffer.from(str, "base64url");
 }
 
-// ── Keypair generation ────────────────────────────────────────────────
+// ── Base58 encode (Solana address format) ─────────────────────────────
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+function base58Encode(buf: Buffer): string {
+  let n = BigInt("0x" + buf.toString("hex"));
+  let out = "";
+  while (n > 0n) {
+    out = BASE58_ALPHABET[Number(n % 58n)] + out;
+    n /= 58n;
+  }
+  for (const byte of buf) {
+    if (byte === 0) out = "1" + out;
+    else break;
+  }
+  return out;
+}
+
+// ── Keypair types ─────────────────────────────────────────────────────
 
 export interface Ed25519Keypair {
+  /** Raw 32-byte seed (used to derive the private key). */
+  seed: Buffer;
+  /** Raw 32-byte public key. */
   publicKey: Buffer;
-  privateKey: Buffer;
+  /** Solana base58-encoded public key address. */
+  address: string;
+}
+
+// ── Keypair derivation ────────────────────────────────────────────────
+
+/**
+ * Derive the Ed25519 public key and Solana address from a 32-byte seed.
+ *
+ * Node.js crypto requires PKCS8 DER wrapping to create an Ed25519 key
+ * from raw bytes. The resulting public key bytes are then base58-encoded
+ * to produce the Solana address.
+ */
+function derivePublicKey(seed: Buffer): { publicKey: Buffer; address: string } {
+  const pkcs8Der = Buffer.concat([PKCS8_ED25519_PREFIX, seed]);
+  const privKey = crypto.createPrivateKey({ key: pkcs8Der, format: "der", type: "pkcs8" });
+  const pubKeyObj = crypto.createPublicKey(privKey);
+  const spki = pubKeyObj.export({ type: "spki", format: "der" }) as Buffer;
+  const publicKey = Buffer.from(spki.subarray(spki.length - 32));
+  return { publicKey, address: base58Encode(publicKey) };
 }
 
 /**
- * Generate a new Ed25519 keypair.
- *
- * Returns raw key buffers: privateKey is the 32-byte seed,
- * publicKey is the 32-byte public key.
+ * Generate a new Ed25519 keypair in BitRouter v0.6.1 web3 format.
  */
 export function generateKeypair(): Ed25519Keypair {
-  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519", {
-    publicKeyEncoding: { type: "spki", format: "der" },
-    privateKeyEncoding: { type: "pkcs8", format: "der" },
-  });
-
-  // Extract raw 32-byte keys from DER encoding.
-  // Ed25519 SPKI DER: 12-byte header + 32-byte public key
-  // Ed25519 PKCS8 DER: 16-byte header + 34-byte wrapper (2-byte prefix + 32-byte seed)
-  const rawPublic = publicKey.subarray(publicKey.length - 32);
-  const rawPrivate = privateKey.subarray(privateKey.length - 32);
-
-  return {
-    publicKey: Buffer.from(rawPublic),
-    privateKey: Buffer.from(rawPrivate),
-  };
+  const seed = crypto.randomBytes(32);
+  const { publicKey, address } = derivePublicKey(seed);
+  return { seed, publicKey, address };
 }
 
 // ── Keypair persistence ───────────────────────────────────────────────
@@ -64,26 +101,19 @@ export function generateKeypair(): Ed25519Keypair {
 const KEY_PREFIX = "openclaw";
 
 /**
- * Save an Ed25519 keypair to BitRouter's key directory format.
+ * Save a keypair to BitRouter's v0.6.1 key directory format.
  *
  * Writes:
- *   <homeDir>/.keys/<prefix>/master.json — the key in BitRouter format
- *   <homeDir>/.keys/active — the active key prefix
+ *   <homeDir>/.keys/<prefix>/master.json — { algorithm: "web3", seed: "<base64url>" }
+ *   <homeDir>/.keys/active              — the active key prefix
  */
-export function saveKeypair(
-  homeDir: string,
-  publicKey: Buffer,
-  privateKey: Buffer
-): void {
+export function saveKeypair(homeDir: string, keypair: Ed25519Keypair): void {
   const keysDir = path.join(homeDir, ".keys", KEY_PREFIX);
   fs.mkdirSync(keysDir, { recursive: true });
 
-  // BitRouter format: 64-byte secret = 32-byte seed + 32-byte public key
-  const secretKey = Buffer.concat([privateKey, publicKey]);
-
   const masterJson = {
-    algorithm: "eddsa",
-    secret_key: base64urlEncode(secretKey),
+    algorithm: "web3",
+    seed: base64urlEncode(keypair.seed),
   };
 
   fs.writeFileSync(
@@ -92,7 +122,6 @@ export function saveKeypair(
     "utf-8"
   );
 
-  // Write active prefix marker.
   fs.writeFileSync(
     path.join(homeDir, ".keys", "active"),
     KEY_PREFIX + "\n",
@@ -101,32 +130,40 @@ export function saveKeypair(
 }
 
 /**
- * Load an existing Ed25519 keypair from the BitRouter key directory.
+ * Load an existing keypair from BitRouter's key directory.
  *
- * Returns null if no keypair is found.
+ * Supports both v0.6.1 "web3" format and legacy v0.4.x "eddsa" format.
+ * Returns null if no valid keypair is found.
  */
 export function loadKeypair(homeDir: string): Ed25519Keypair | null {
   try {
-    // Read the active prefix.
     const activePath = path.join(homeDir, ".keys", "active");
     const prefix = fs.readFileSync(activePath, "utf-8").trim();
 
-    // Read master.json.
     const masterPath = path.join(homeDir, ".keys", prefix, "master.json");
     const masterJson = JSON.parse(fs.readFileSync(masterPath, "utf-8")) as {
       algorithm: string;
-      secret_key: string;
+      seed?: string;
+      secret_key?: string;
     };
 
-    if (masterJson.algorithm !== "eddsa") return null;
+    let seed: Buffer;
 
-    const secretKey = base64urlDecode(masterJson.secret_key);
-    if (secretKey.length !== 64) return null;
+    if (masterJson.algorithm === "web3" && masterJson.seed) {
+      // v0.6.1 format: 32-byte seed, base64url-encoded.
+      seed = base64urlDecode(masterJson.seed);
+      if (seed.length !== 32) return null;
+    } else if (masterJson.algorithm === "eddsa" && masterJson.secret_key) {
+      // Legacy v0.4.x format: 64-byte seed+pubkey, first 32 bytes = seed.
+      const secretKey = base64urlDecode(masterJson.secret_key);
+      if (secretKey.length !== 64) return null;
+      seed = Buffer.from(secretKey.subarray(0, 32));
+    } else {
+      return null;
+    }
 
-    return {
-      privateKey: Buffer.from(secretKey.subarray(0, 32)),
-      publicKey: Buffer.from(secretKey.subarray(32, 64)),
-    };
+    const { publicKey, address } = derivePublicKey(seed);
+    return { seed, publicKey, address };
   } catch {
     return null;
   }
@@ -135,35 +172,29 @@ export function loadKeypair(homeDir: string): Ed25519Keypair | null {
 // ── JWT minting ───────────────────────────────────────────────────────
 
 /**
- * Mint a JWT signed with EdDSA (Ed25519).
+ * Mint a SOL_EDDSA JWT for BitRouter v0.6.1.
  *
- * Produces: base64url(header).base64url(claims).base64url(signature)
- * No padding, per BitRouter's token format.
+ * Header: { alg: "SOL_EDDSA", typ: "JWT" }
+ * Claims: { iss: "solana:<chain>:<address>", chain: "solana:<chain>", ...extra }
  */
 export function mintJwt(
-  privateKey: Buffer,
-  publicKey: Buffer,
+  keypair: Ed25519Keypair,
   claims: Record<string, unknown>
 ): string {
-  const header = { alg: "EdDSA", typ: "JWT" };
+  const header = { alg: "SOL_EDDSA", typ: "JWT" };
+
+  const fullClaims = {
+    iss: `solana:${SOLANA_CHAIN_ID}:${keypair.address}`,
+    chain: `solana:${SOLANA_CHAIN_ID}`,
+    ...claims,
+  };
 
   const headerB64 = base64urlEncode(Buffer.from(JSON.stringify(header)));
-  const claimsB64 = base64urlEncode(Buffer.from(JSON.stringify(claims)));
+  const claimsB64 = base64urlEncode(Buffer.from(JSON.stringify(fullClaims)));
   const signingInput = `${headerB64}.${claimsB64}`;
 
-  // Reconstruct the Node.js key object from raw bytes for signing.
-  // Ed25519 PKCS8 DER: fixed prefix + 32-byte seed
-  const pkcs8Prefix = Buffer.from(
-    "302e020100300506032b657004220420",
-    "hex"
-  );
-  const pkcs8Der = Buffer.concat([pkcs8Prefix, privateKey]);
-  const keyObject = crypto.createPrivateKey({
-    key: pkcs8Der,
-    format: "der",
-    type: "pkcs8",
-  });
-
+  const pkcs8Der = Buffer.concat([PKCS8_ED25519_PREFIX, keypair.seed]);
+  const keyObject = crypto.createPrivateKey({ key: pkcs8Der, format: "der", type: "pkcs8" });
   const signature = crypto.sign(null, Buffer.from(signingInput), keyObject);
 
   return `${signingInput}.${base64urlEncode(signature)}`;
@@ -189,20 +220,43 @@ function decodeExp(jwt: string): number | null {
 // ── High-level API ────────────────────────────────────────────────────
 
 /**
- * Ensure a keypair exists and return both API-scope and admin-scope JWTs.
+ * Ensure a keypair exists in the homeDir and return both API-scope
+ * and admin-scope JWTs signed with SOL_EDDSA (BitRouter v0.6.1).
  *
- * API token: no iat/exp, scope "api", cached at tokens/plugin.jwt.
- * Admin token: scope "admin", 24h expiry, cached at tokens/admin.jwt.
- *   Re-minted if the cached token expires within 1 hour.
+ * If a v0.6.1-format keypair ("web3") already exists it is reused.
+ * If only a legacy v0.4.x keypair ("eddsa") is found, a new v0.6.1
+ * keypair is generated and saved (the legacy one is left in place).
  *
- * @returns Both JWT strings for authenticating with BitRouter.
+ * API token:   scope "api",   no expiry, cached at tokens/plugin.jwt.
+ * Admin token: scope "admin", 24h expiry, cached at tokens/admin.jwt,
+ *              re-minted when within 1h of expiry.
  */
 export function ensureAuth(homeDir: string): { apiToken: string; adminToken: string } {
   let keypair = loadKeypair(homeDir);
 
-  if (!keypair) {
+  // Regenerate if missing or if we loaded a legacy keypair (algorithm mismatch).
+  const masterPath = (() => {
+    try {
+      const prefix = fs.readFileSync(path.join(homeDir, ".keys", "active"), "utf-8").trim();
+      return path.join(homeDir, ".keys", prefix, "master.json");
+    } catch {
+      return null;
+    }
+  })();
+
+  const isLegacy = (() => {
+    if (!masterPath) return false;
+    try {
+      const m = JSON.parse(fs.readFileSync(masterPath, "utf-8")) as { algorithm?: string };
+      return m.algorithm !== "web3";
+    } catch {
+      return false;
+    }
+  })();
+
+  if (!keypair || isLegacy) {
     keypair = generateKeypair();
-    saveKeypair(homeDir, keypair.publicKey, keypair.privateKey);
+    saveKeypair(homeDir, keypair);
   }
 
   const activePath = path.join(homeDir, ".keys", "active");
@@ -221,10 +275,7 @@ export function ensureAuth(homeDir: string): { apiToken: string; adminToken: str
   }
 
   if (!apiToken) {
-    apiToken = mintJwt(keypair.privateKey, keypair.publicKey, {
-      iss: base64urlEncode(keypair.publicKey),
-      scope: "api",
-    });
+    apiToken = mintJwt(keypair, { scope: "api" });
     fs.mkdirSync(path.dirname(apiTokenPath), { recursive: true });
     fs.writeFileSync(apiTokenPath, apiToken + "\n", "utf-8");
   }
@@ -241,7 +292,6 @@ export function ensureAuth(homeDir: string): { apiToken: string; adminToken: str
       if (exp && exp - now > 3600) {
         adminToken = cached;
       }
-      // else: expired or about to expire — re-mint below.
     }
   } catch {
     // No cached token — mint below.
@@ -249,8 +299,7 @@ export function ensureAuth(homeDir: string): { apiToken: string; adminToken: str
 
   if (!adminToken) {
     const now = Math.floor(Date.now() / 1000);
-    adminToken = mintJwt(keypair.privateKey, keypair.publicKey, {
-      iss: base64urlEncode(keypair.publicKey),
+    adminToken = mintJwt(keypair, {
       scope: "admin",
       iat: now,
       exp: now + 86400,

--- a/openclaw/tests/integration.test.ts
+++ b/openclaw/tests/integration.test.ts
@@ -24,11 +24,12 @@ import { generateConfig } from "../src/config.js";
 import { activate } from "../src/index.js";
 import { ensureAuth } from "../src/auth.js";
 import * as os from "node:os";
+import * as path from "node:path";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
 const BITROUTER_URL = "http://127.0.0.1:8787";
-const HOME_DIR = os.homedir();
+const HOME_DIR = path.join(os.homedir(), ".openclaw", "bitrouter");
 
 /** Check if BitRouter is actually running before tests. */
 async function isBitrouterRunning(): Promise<boolean> {
@@ -373,13 +374,13 @@ describe("Integration: plugin against live BitRouter", () => {
     it("sends a chat completion through BitRouter and gets a response", async () => {
       if (!running) return;
 
-      const jwt = ensureAuth(HOME_DIR);
+      const { apiToken } = ensureAuth(HOME_DIR);
 
       const res = await fetch(`${BITROUTER_URL}/v1/chat/completions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "Authorization": `Bearer ${jwt}`,
+          "Authorization": `Bearer ${apiToken}`,
         },
         body: JSON.stringify({
           model: "default",

--- a/openclaw/tests/service.test.ts
+++ b/openclaw/tests/service.test.ts
@@ -42,7 +42,7 @@ vi.mock("../src/metrics.js", () => ({
 }));
 
 vi.mock("../src/auth.js", () => ({
-  ensureAuth: vi.fn(() => "mock-jwt-token"),
+  ensureAuth: vi.fn(() => ({ apiToken: "mock-api-jwt", adminToken: "mock-admin-jwt" })),
 }));
 
 vi.mock("../src/auto-detect.js", () => ({


### PR DESCRIPTION
## Summary

- Rewrites \`auth.ts\` to generate and sign JWTs using BitRouter v0.6.1's \`web3\` keypair format (Solana-compatible Ed25519, \`SOL_EDDSA\` algorithm) instead of the removed legacy \`eddsa\` format.
- Adds \`openclaw.extensions\` to \`package.json\`, required by the OpenClaw plugin installer since v2026.3.8.
- Fixes two bugs in \`integration.test.ts\` exposed by the auth rewrite (wrong \`HOME_DIR\` path, object-instead-of-string passed as bearer token).
- Updates \`service.test.ts\` mock to match the real \`ensureAuth\` return shape.

## What broke

BitRouter v0.6.1 changed its keypair format:

| | v0.4.x (old) | v0.6.1 (new) |
|---|---|---|
| \`master.json\` | \`{ algorithm: \"eddsa\", secret_key: \"<base64url 64B>\" }\` | \`{ algorithm: \"web3\", seed: \"<base64url 32B>\" }\` |
| JWT \`alg\` | \`EdDSA\` | \`SOL_EDDSA\` |
| \`iss\` claim | \`<base64url pubkey>\` | \`solana:<chain-id>:<base58 pubkey>\` |

The old plugin generated \`EdDSA\` JWTs that v0.6.1 rejected with \`401: invalid JWT signature\` on every authenticated endpoint (\`/v1/metrics\`, \`/admin/routes\`, \`/accounts\`, and all LLM proxy calls routed through the bitrouter provider).

## Migration

\`ensureAuth\` now detects a legacy \`eddsa\` key on load and transparently regenerates a \`web3\` keypair on the next call. Existing installations auto-migrate on gateway restart for plugin-internal tokens. The credential stored in openclaw's auth profile store requires a manual re-run of \`openclaw models auth login --provider bitrouter\` — see #13 for discussion on auto-migrating that.

## Testing

- All 38 unit + integration tests pass (including live end-to-end LLM call through BitRouter).
- Verified manually under a real openclaw agent run: all 7 BitRouter plugin tools (\`bitrouter_status\`, \`bitrouter_list_routes\`, \`bitrouter_add_route\`, \`bitrouter_keygen\`, \`bitrouter_remove_route\`) exercised successfully with a live subagent delegation task.

## Related

Fixes #12 (auth.ts keypair format mismatch with v0.6.1)  
Fixes #14 (missing \`openclaw.extensions\` in package.json)  
Partially addresses #13 (stale credential in openclaw store not auto-migrated — see issue for full discussion)