### PR TITLE
ci(automation): add workflow to open issue on bitrouter release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      openclaw:
+        patterns:
+          - "openclaw"
+    open-pull-requests-limit: 10

--- a/.github/workflows/on-bitrouter-release.yml
+++ b/.github/workflows/on-bitrouter-release.yml
@@ -1,0 +1,69 @@
+name: On BitRouter Release
+
+on:
+  repository_dispatch:
+    types: [bitrouter-release]
+
+jobs:
+  open-issue:
+    name: Open update issue
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Fetch release notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ github.event.client_payload.tag }}" \
+            --repo bitrouter/bitrouter \
+            --json body \
+            --jq '.body' > release_notes.md
+
+      - name: Build issue body
+        run: |
+          TAG="${{ github.event.client_payload.tag }}"
+          cat > issue_body.md <<EOF
+          ## BitRouter $TAG released — plugin update needed
+
+          <details>
+          <summary>Release notes</summary>
+
+          $(cat release_notes.md)
+
+          </details>
+
+          ### Checklist
+
+          **Version pin**
+          - [ ] Update \`BITROUTER_VERSION\` in \`src/binary.ts\` to match new release
+          - [ ] Verify download URLs resolve for all platforms (macOS, Linux, Windows × arm64/x86_64)
+
+          **Interface compatibility**
+          - [ ] Review HTTP API surface changes — check \`src/http-routes.ts\` against new endpoints
+          - [ ] Review config schema changes — check \`src/config.ts\` against new config fields
+          - [ ] Review provider discovery changes — check \`src/discovery.ts\` if provider list changed
+          - [ ] Update \`openclaw.plugin.json\` schema if new config options were added
+
+          **Breaking changes** (if any)
+          - [ ] Add \`TODO\` comments in adapter code where fix is uncertain
+          - [ ] Update \`package.json\` version (minor bump for compatible, major for breaking)
+
+          **Tests**
+          - [ ] Run \`npm test\` to verify existing tests pass against new version
+          - [ ] Add tests for any new integration points
+
+          ---
+          *Opened automatically by [release-propagate](https://github.com/bitrouter/bitrouter/actions/workflows/release-propagate.yml)*
+          EOF
+
+      - name: Create issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "chore: update for BitRouter ${{ github.event.client_payload.tag }}" \
+            --body-file issue_body.md \
+            --label "chore,automation"

--- a/.github/workflows/on-bitrouter-release.yml
+++ b/.github/workflows/on-bitrouter-release.yml
@@ -5,65 +5,49 @@ on:
     types: [bitrouter-release]
 
 jobs:
-  open-issue:
-    name: Open update issue
+  update-plugin:
+    name: Update plugin for new release
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      id-token: write
+      contents: write
+      pull-requests: write
       issues: write
     steps:
-      - name: Fetch release notes
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: anomalyco/opencode/github@latest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release view "${{ github.event.client_payload.tag }}" \
-            --repo bitrouter/bitrouter \
-            --json body \
-            --jq '.body' > release_notes.md
+          BITROUTER_API_KEY: ${{ secrets.BITROUTER_API_KEY }}
+        with:
+          model: bitrouter/kimi-k2.5
+          prompt: |
+            BitRouter ${{ github.event.client_payload.tag }} was just released.
 
-      - name: Build issue body
-        run: |
-          TAG="${{ github.event.client_payload.tag }}"
-          cat > issue_body.md <<EOF
-          ## BitRouter $TAG released — plugin update needed
+            Fetch the release notes by running:
+              gh release view ${{ github.event.client_payload.tag }} --repo bitrouter/bitrouter --json body --jq '.body'
 
-          <details>
-          <summary>Release notes</summary>
+            Based on the release notes, update this plugin repo:
 
-          $(cat release_notes.md)
+            1. Version pin:
+               - Update BITROUTER_VERSION in src/binary.ts to match the new release version (strip the leading "v")
+               - Verify the download URL pattern in src/binary.ts still matches the release asset naming
 
-          </details>
+            2. Interface compatibility:
+               - Check src/http-routes.ts against any new or changed API endpoints mentioned in the notes
+               - Check src/config.ts against any new config fields
+               - Check src/discovery.ts if the provider list changed
+               - Update openclaw.plugin.json schema if new config options were added
 
-          ### Checklist
+            3. Breaking changes (if feat!: or BREAKING CHANGE appears in the notes):
+               - If you can confidently fix the adapter code, do so
+               - If the fix is uncertain, add a TODO comment explaining what needs attention
+               - Flag breaking changes explicitly in the PR body
 
-          **Version pin**
-          - [ ] Update \`BITROUTER_VERSION\` in \`src/binary.ts\` to match new release
-          - [ ] Verify download URLs resolve for all platforms (macOS, Linux, Windows × arm64/x86_64)
+            4. Run `npm test` and fix any failures caused by your changes
 
-          **Interface compatibility**
-          - [ ] Review HTTP API surface changes — check \`src/http-routes.ts\` against new endpoints
-          - [ ] Review config schema changes — check \`src/config.ts\` against new config fields
-          - [ ] Review provider discovery changes — check \`src/discovery.ts\` if provider list changed
-          - [ ] Update \`openclaw.plugin.json\` schema if new config options were added
-
-          **Breaking changes** (if any)
-          - [ ] Add \`TODO\` comments in adapter code where fix is uncertain
-          - [ ] Update \`package.json\` version (minor bump for compatible, major for breaking)
-
-          **Tests**
-          - [ ] Run \`npm test\` to verify existing tests pass against new version
-          - [ ] Add tests for any new integration points
-
-          ---
-          *Opened automatically by [release-propagate](https://github.com/bitrouter/bitrouter/actions/workflows/release-propagate.yml)*
-          EOF
-
-      - name: Create issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh issue create \
-            --repo "${{ github.repository }}" \
-            --title "chore: update for BitRouter ${{ github.event.client_payload.tag }}" \
-            --body-file issue_body.md \
-            --label "chore,automation"
+            Only modify files where the release notes indicate actual changes. Do not make speculative edits.
+            Open a PR to main with branch chore/plugins-${{ github.event.client_payload.tag }}.

--- a/.github/workflows/on-openclaw-update.yml
+++ b/.github/workflows/on-openclaw-update.yml
@@ -1,0 +1,77 @@
+name: On OpenClaw Update
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  compat-check:
+    name: OpenClaw compatibility check
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      contains(github.event.pull_request.title, 'openclaw')
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Get new openclaw version
+        id: version
+        run: |
+          NEW_VERSION=$(node -e "console.log(require('./node_modules/openclaw/package.json').version)")
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: anomalyco/opencode/github@latest
+        env:
+          BITROUTER_API_KEY: ${{ secrets.BITROUTER_API_KEY }}
+        with:
+          model: bitrouter/kimi-k2.5
+          prompt: |
+            OpenClaw has been updated to version ${{ steps.version.outputs.new_version }}.
+            This is a Dependabot PR: "${{ github.event.pull_request.title }}"
+
+            Check if this plugin is compatible with the new OpenClaw version and fix any issues.
+
+            1. Check for OpenClaw release notes or changelog:
+               - Run: npm view openclaw@${{ steps.version.outputs.new_version }} --json
+               - Look for a CHANGELOG in node_modules/openclaw/ if available
+
+            2. Verify interface compatibility — check each file against the installed openclaw SDK types:
+               - src/types.ts imports from "openclaw/plugin-sdk" — verify all imported types still exist
+               - src/index.ts uses api.registerService(), api.registerProvider(), api.registerCli(),
+                 api.registerHttpRoute(), api.on(), api.pluginConfig, api.config.agents.defaults.model, api.logger
+               - src/service.ts uses OpenClawPluginServiceContext
+               - src/provider.ts uses ProviderAuthContext, ProviderAuthResult
+               - src/routing.ts uses the before_model_resolve hook event and result types
+               - src/prompt-context.ts uses the before_prompt_build hook
+               - src/http-routes.ts uses registerHttpRoute()
+               - Compare against the .d.ts files in node_modules/openclaw/ for any changed or removed exports
+
+            3. Run `npm run build` to check TypeScript compilation. Fix any type errors.
+
+            4. Run `npm test` to verify all tests pass. Fix any failures caused by the update.
+
+            5. If you find breaking changes:
+               - If you can confidently fix the code, do so
+               - If the fix is uncertain, add a TODO comment explaining what needs attention
+               - Update the PR body to flag breaking changes
+
+            6. If no code changes are needed beyond the version bump, comment on the PR:
+               "Verified compatible with openclaw@${{ steps.version.outputs.new_version }}"
+
+            Do NOT auto-merge this PR. A human must review and merge.
+            Do NOT make speculative edits — only fix actual compilation or test failures.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "bitrouter": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": {
+        "baseURL": "https://api.bitrouter.ai/v1",
+        "apiKey": "{env:BITROUTER_API_KEY}"
+      },
+      "models": {
+        "kimi-k2.5": {
+          "name": "Kimi K2.5 via BitRouter"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `on-bitrouter-release.yml` that receives `bitrouter-release` dispatch from the core repo
- Opens an issue with a plugin update checklist covering version pin (`BITROUTER_VERSION`), interface compatibility, and breaking change handling
- Part of the cross-repo release propagation pipeline

## Test plan
- [ ] Merge this PR
- [ ] Dispatch test event: `gh api repos/bitrouter/bitrouter-openclaw/dispatches -f event_type=bitrouter-release -f 'client_payload[tag]=v0.11.0'`
- [ ] Verify issue is created with correct title, release notes, and checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)