### PR TITLE
fix(config): use object format for skills required_apis

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -244,7 +244,7 @@ export function generateConfig(
       description: skill.description,
       ...(skill.source && { source: skill.source }),
       ...(skill.requiredApis && {
-        required_apis: skill.requiredApis.map((a) => a.provider),
+        required_apis: skill.requiredApis.map((a) => ({ provider: a.provider })),
       }),
     }));
   }


### PR DESCRIPTION
## Summary

- Fix `required_apis` serialization in skills config to use object format `[{provider: "name"}]` instead of flat strings `["name"]`
- Without this fix, when `skills` are configured in the plugin config, the entire `bitrouter.yaml` fails to deserialize and BitRouter falls back to empty defaults — silently losing all providers, models, A2A agents, and MCP servers

## Test plan

- [x] All 82 tests pass
- [x] Verified config generates correct YAML: `required_apis: [{provider: anthropic}]`
- [x] Verified BitRouter starts without config parse errors
- [x] Verified A2A, MCP, and skills all initialize correctly with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)