### PR TITLE
feat: expand plugin to hybrid-capability with unified tool, MCP bridge, and usage tracking

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4,7 +4,9 @@
   "version": "0.1.0",
   "description": "Route LLM requests through BitRouter — a local multi-provider proxy with failover, load balancing, and unified API key management.",
   "entry": "dist/index.js",
-  "skills": ["skills/bitrouter"],
+  "skills": [
+    "skills/bitrouter"
+  ],
   "configSchema": {
     "type": "object",
     "properties": {
@@ -69,17 +71,33 @@
           },
           "disabledPatterns": {
             "type": "array",
-            "items": { "type": "string" },
+            "items": {
+              "type": "string"
+            },
             "description": "Built-in patterns to disable (e.g. 'ip_addresses')."
           },
           "upgoing": {
             "type": "object",
-            "additionalProperties": { "type": "string", "enum": ["warn", "redact", "block"] },
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "warn",
+                "redact",
+                "block"
+              ]
+            },
             "description": "Per-pattern action for outbound traffic (user → LLM)."
           },
           "downgoing": {
             "type": "object",
-            "additionalProperties": { "type": "string", "enum": ["warn", "redact", "block"] },
+            "additionalProperties": {
+              "type": "string",
+              "enum": [
+                "warn",
+                "redact",
+                "block"
+              ]
+            },
             "description": "Per-pattern action for inbound traffic (LLM → user)."
           },
           "customPatterns": {
@@ -87,11 +105,26 @@
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "regex": { "type": "string" },
-                "direction": { "type": "string", "enum": ["upgoing", "downgoing", "both"], "default": "upgoing" }
+                "name": {
+                  "type": "string"
+                },
+                "regex": {
+                  "type": "string"
+                },
+                "direction": {
+                  "type": "string",
+                  "enum": [
+                    "upgoing",
+                    "downgoing",
+                    "both"
+                  ],
+                  "default": "upgoing"
+                }
               },
-              "required": ["name", "regex"]
+              "required": [
+                "name",
+                "regex"
+              ]
             },
             "description": "User-defined regex patterns."
           }
@@ -105,7 +138,10 @@
           "properties": {
             "strategy": {
               "type": "string",
-              "enum": ["priority", "load_balance"],
+              "enum": [
+                "priority",
+                "load_balance"
+              ],
               "default": "priority",
               "description": "'priority' tries endpoints in order with failover. 'load_balance' distributes via round-robin."
             },
@@ -131,11 +167,16 @@
                     "description": "Optional per-endpoint API base URL override."
                   }
                 },
-                "required": ["provider", "modelId"]
+                "required": [
+                  "provider",
+                  "modelId"
+                ]
               }
             }
           },
-          "required": ["endpoints"]
+          "required": [
+            "endpoints"
+          ]
         }
       },
       "solanaRpcUrl": {
@@ -168,7 +209,9 @@
             },
             "headers": {
               "type": "object",
-              "additionalProperties": { "type": "string" },
+              "additionalProperties": {
+                "type": "string"
+              },
               "description": "Custom headers to send to the upstream agent."
             },
             "cardPath": {
@@ -176,7 +219,10 @@
               "description": "Optional local path to cache the agent card."
             }
           },
-          "required": ["name", "url"]
+          "required": [
+            "name",
+            "url"
+          ]
         }
       },
       "a2aAgentPricing": {
@@ -185,10 +231,15 @@
         "additionalProperties": {
           "type": "object",
           "properties": {
-            "defaultCostPerCall": { "type": "number", "description": "Default cost per method call." },
+            "defaultCostPerCall": {
+              "type": "number",
+              "description": "Default cost per method call."
+            },
             "overrides": {
               "type": "object",
-              "additionalProperties": { "type": "number" },
+              "additionalProperties": {
+                "type": "number"
+              },
               "description": "Per-method cost overrides (e.g. 'message/send': 0.002)."
             }
           }
@@ -210,14 +261,26 @@
             },
             "args": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": "Arguments for the server command."
             },
             "toolFilter": {
               "type": "object",
               "properties": {
-                "allow": { "type": "array", "items": { "type": "string" } },
-                "deny": { "type": "array", "items": { "type": "string" } }
+                "allow": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "deny": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               },
               "description": "Allow/deny list for tool names."
             },
@@ -229,17 +292,29 @@
                   "items": {
                     "type": "object",
                     "properties": {
-                      "tool": { "type": "string" },
-                      "forbiddenParams": { "type": "array", "items": { "type": "string" } }
+                      "tool": {
+                        "type": "string"
+                      },
+                      "forbiddenParams": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
                     },
-                    "required": ["tool"]
+                    "required": [
+                      "tool"
+                    ]
                   }
                 }
               },
               "description": "Per-tool parameter restrictions."
             }
           },
-          "required": ["name", "command"]
+          "required": [
+            "name",
+            "command"
+          ]
         }
       },
       "mcpGroups": {
@@ -247,7 +322,9 @@
         "description": "Named groups of MCP servers for access control.",
         "additionalProperties": {
           "type": "array",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
       "mcpServerPricing": {
@@ -256,10 +333,15 @@
         "additionalProperties": {
           "type": "object",
           "properties": {
-            "defaultCostPerCall": { "type": "number", "description": "Default cost per tool call." },
+            "defaultCostPerCall": {
+              "type": "number",
+              "description": "Default cost per tool call."
+            },
             "overrides": {
               "type": "object",
-              "additionalProperties": { "type": "number" },
+              "additionalProperties": {
+                "type": "number"
+              },
               "description": "Per-tool cost overrides."
             }
           }
@@ -271,27 +353,47 @@
         "items": {
           "type": "object",
           "properties": {
-            "name": { "type": "string", "description": "Skill name." },
-            "description": { "type": "string", "description": "Skill description." },
-            "source": { "type": "string", "description": "Optional source URL." },
+            "name": {
+              "type": "string",
+              "description": "Skill name."
+            },
+            "description": {
+              "type": "string",
+              "description": "Skill description."
+            },
+            "source": {
+              "type": "string",
+              "description": "Optional source URL."
+            },
             "requiredApis": {
               "type": "array",
               "items": {
                 "type": "object",
                 "properties": {
-                  "provider": { "type": "string" }
+                  "provider": {
+                    "type": "string"
+                  }
                 },
-                "required": ["provider"]
+                "required": [
+                  "provider"
+                ]
               },
               "description": "APIs required by this skill."
             }
           },
-          "required": ["name", "description"]
+          "required": [
+            "name",
+            "description"
+          ]
         }
       },
       "mode": {
         "type": "string",
-        "enum": ["byok", "cloud", "auto"],
+        "enum": [
+          "byok",
+          "cloud",
+          "auto"
+        ],
         "description": "Setup mode. 'auto' = detected from environment variables. 'byok' = bring your own API key (wizard). 'cloud' = Swig wallet for x402 payments. Unset = not yet configured and no env vars found."
       },
       "byok": {
@@ -307,12 +409,19 @@
             "description": "Custom API base URL. Defaults to the provider's public URL."
           }
         },
-        "required": ["upstreamProvider"]
+        "required": [
+          "upstreamProvider"
+        ]
       }
     }
   },
   "providerAuthEnvVars": {
-    "bitrouter": ["BITROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY"]
+    "bitrouter": [
+      "BITROUTER_API_KEY",
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "OPENROUTER_API_KEY"
+    ]
   },
   "providerAuthChoices": [
     {
@@ -340,6 +449,34 @@
       "cliDescription": "Upstream provider API key for BYOK mode"
     }
   ],
+  "modelSupport": {
+    "modelPrefixes": [
+      "bitrouter/"
+    ]
+  },
+  "activation": {
+    "onProviders": [
+      "bitrouter"
+    ],
+    "onCapabilities": [
+      "provider",
+      "tool"
+    ]
+  },
+  "setup": {
+    "providers": [
+      {
+        "id": "bitrouter",
+        "label": "BitRouter",
+        "hint": "Local multi-provider LLM proxy with failover and load balancing"
+      }
+    ]
+  },
+  "contracts": {
+    "tools": [
+      "bitrouter"
+    ]
+  },
   "uiHints": {
     "icon": "router",
     "category": "infrastructure",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     ],
     "providers": [
       "bitrouter"
-    ]
+    ],
+    "compat": ">=2026.3.24",
+    "build": "pnpm run build"
   },
   "license": "MIT",
   "repository": {

--- a/src/binary.ts
+++ b/src/binary.ts
@@ -1,11 +1,11 @@
 /**
- * Binary resolution — downloads and caches the BitRouter binary from GitHub
- * releases, or falls back to finding it on $PATH.
+ * Binary resolution — prefers a system-installed `bitrouter` on $PATH,
+ * then falls back to a cached/downloaded copy from GitHub releases.
  *
  * Resolution order:
- * 1. Cached binary in the plugin's data directory ({dataDir}/bin/bitrouter)
- * 2. Auto-download from GitHub releases (cached for future use)
- * 3. `bitrouter` on $PATH (for users who installed manually)
+ * 1. `bitrouter` on $PATH (for users who installed via cargo/brew/etc.)
+ * 2. Cached binary in the plugin's data directory ({dataDir}/bin/bitrouter)
+ * 3. Auto-download from GitHub releases (cached for future use)
  */
 
 import { execSync } from "node:child_process";
@@ -73,7 +73,8 @@ function getAssetName(): string {
 async function downloadBinary(binDir: string): Promise<string> {
   const asset = getAssetName();
   const url = `${GITHUB_DOWNLOAD_BASE}/${asset}`;
-  const binaryName = process.platform === "win32" ? "bitrouter.exe" : "bitrouter";
+  const binaryName =
+    process.platform === "win32" ? "bitrouter.exe" : "bitrouter";
   const binaryPath = join(binDir, binaryName);
   const archivePath = join(binDir, asset);
 
@@ -82,7 +83,9 @@ async function downloadBinary(binDir: string): Promise<string> {
   // Download the archive.
   const res = await fetch(url, { redirect: "follow" });
   if (!res.ok || !res.body) {
-    throw new Error(`Failed to download ${url}: ${res.status} ${res.statusText}`);
+    throw new Error(
+      `Failed to download ${url}: ${res.status} ${res.statusText}`,
+    );
   }
 
   const buffer = Buffer.from(await res.arrayBuffer());
@@ -108,11 +111,29 @@ async function downloadBinary(binDir: string): Promise<string> {
   if (!existsSync(binaryPath)) {
     throw new Error(
       `Download succeeded but binary not found at ${binaryPath}. ` +
-        `Archive may have an unexpected structure.`
+        `Archive may have an unexpected structure.`,
     );
   }
 
   return binaryPath;
+}
+
+/**
+ * Synchronously check if `bitrouter` is available on the system $PATH.
+ * Returns the resolved path or `null` if not found.
+ */
+export function findSystemBinary(): string | null {
+  try {
+    const cmd =
+      process.platform === "win32" ? "where bitrouter" : "which bitrouter";
+    const result = execSync(cmd, {
+      encoding: "utf-8",
+      timeout: 5_000,
+    }).trim();
+    return result ? result.split("\n")[0] : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -121,10 +142,17 @@ async function downloadBinary(binDir: string): Promise<string> {
  * @param dataDir - The plugin's persistent data directory (from api.getDataDir()).
  *                  Pass `null` to skip cached/download resolution and only check PATH.
  */
-export async function resolveBinaryPath(dataDir: string | null): Promise<string> {
-  const binaryName = process.platform === "win32" ? "bitrouter.exe" : "bitrouter";
+export async function resolveBinaryPath(
+  dataDir: string | null,
+): Promise<string> {
+  const binaryName =
+    process.platform === "win32" ? "bitrouter.exe" : "bitrouter";
 
-  // Try 1: Cached binary in data directory.
+  // Try 1: binary on PATH (preferred — user-managed install).
+  const systemBinary = findSystemBinary();
+  if (systemBinary) return systemBinary;
+
+  // Try 2: Cached binary in data directory.
   if (dataDir) {
     const binDir = join(dataDir, "bin");
     const cachedPath = join(binDir, binaryName);
@@ -142,24 +170,12 @@ export async function resolveBinaryPath(dataDir: string | null): Promise<string>
       }
     }
 
-    // Try 2: Download from GitHub releases.
+    // Try 3: Download from GitHub releases.
     try {
       return await downloadBinary(binDir);
     } catch {
-      // Download failed — fall through to PATH.
+      // Download failed — fall through.
     }
-  }
-
-  // Try 3: binary on PATH.
-  try {
-    const cmd = process.platform === "win32" ? "where bitrouter" : "which bitrouter";
-    const result = execSync(cmd, {
-      encoding: "utf-8",
-      timeout: 5_000,
-    }).trim();
-    if (result) return result.split("\n")[0];
-  } catch {
-    // Not on PATH — fall through.
   }
 
   throw new Error(
@@ -169,6 +185,6 @@ export async function resolveBinaryPath(dataDir: string | null): Promise<string>
       `  Download from: ${GITHUB_DOWNLOAD_BASE}\n` +
       "  Or: cargo install bitrouter\n" +
       "\n" +
-      "Then ensure `bitrouter` is on your $PATH."
+      "Then ensure `bitrouter` is on your $PATH.",
   );
 }

--- a/src/bitrouter-cli.ts
+++ b/src/bitrouter-cli.ts
@@ -1,19 +1,22 @@
 /**
- * Thin wrapper around the `bitrouter` CLI for account and token management.
+ * Thin wrapper around the `bitrouter` CLI for wallet and token management.
  *
- * Instead of reimplementing keypair generation and JWT signing (which the
- * plugin previously did in auth.ts), we delegate to the bitrouter binary:
+ * Instead of reimplementing keypair generation and JWT signing, we delegate
+ * to the bitrouter binary:
  *
- *   `bitrouter account`  — manage wallet keypairs
- *   `bitrouter keygen`   — mint fresh JWTs signed by the active account key
- *   `bitrouter keys`     — list/inspect saved tokens
+ *   `bitrouter wallet`  — manage OWS wallets (create, list, info)
+ *   `bitrouter key sign` — mint fresh JWTs signed by a wallet key
+ *   `bitrouter auth`    — provider authentication (login, status)
  *
  * This keeps the wallet identity owned by bitrouter (not the plugin) and
  * avoids drift when bitrouter updates its auth format.
  */
 
-import { execFile } from "node:child_process";
+import { execFile, spawnSync } from "node:child_process";
 import { resolveBinaryPath } from "./binary.js";
+
+/** Default wallet name used by the plugin for automated JWT signing. */
+const PLUGIN_WALLET_NAME = "openclaw";
 
 /** Cached binary path — resolved once per process. */
 let cachedBinaryPath: string | null = null;
@@ -35,6 +38,9 @@ async function getBinaryPath(stateDir: string): Promise<string> {
 
 /**
  * Run a bitrouter CLI command and return stdout.
+ *
+ * Sets OWS_PASSPHRASE to empty string when not already in env,
+ * so wallet operations work non-interactively (empty passphrase).
  */
 async function runBitrouter(
   stateDir: string,
@@ -46,10 +52,21 @@ async function runBitrouter(
     execFile(
       binaryPath,
       ["--home-dir", homeDir, ...args],
-      { timeout: 10_000 },
+      {
+        timeout: 15_000,
+        env: {
+          ...process.env,
+          // Allow non-interactive wallet/key operations with empty passphrase.
+          OWS_PASSPHRASE: process.env.OWS_PASSPHRASE ?? "",
+        },
+      },
       (err, stdout, stderr) => {
         if (err) {
-          reject(new Error(`bitrouter ${args.join(" ")} failed: ${stderr || err.message}`));
+          reject(
+            new Error(
+              `bitrouter ${args.join(" ")} failed: ${stderr || err.message}`,
+            ),
+          );
         } else {
           resolve(stdout.trim());
         }
@@ -59,85 +76,178 @@ async function runBitrouter(
 }
 
 /**
- * Check whether the bitrouter CLI has an active account keypair.
+ * Check whether the plugin's OWS wallet exists.
  *
- * Returns true if `bitrouter account --list` shows at least one key
- * with an active marker.
+ * Parses `bitrouter wallet list` output and looks for a row whose NAME
+ * column matches the plugin wallet name. The CLI also emits a version
+ * upgrade notice to stderr, but `wallet list` prints the table to stdout.
  */
-export async function hasActiveAccount(
+export async function hasWallet(
   stateDir: string,
   homeDir: string,
+  walletName: string = PLUGIN_WALLET_NAME,
 ): Promise<boolean> {
   try {
-    const output = await runBitrouter(stateDir, homeDir, ["account", "--list"]);
-    // The list output marks the active key with "*"
-    return output.includes("*");
+    const output = await runBitrouter(stateDir, homeDir, ["wallet", "list"]);
+    // Rows look like: `openclaw              <uuid>   <chains>`.
+    // Match the wallet name at the start of a line (possibly after whitespace).
+    const pattern = new RegExp(`^\\s*${escapeRegex(walletName)}\\s+`, "m");
+    return pattern.test(output);
   } catch {
     return false;
   }
 }
 
 /**
- * Generate a new account keypair via `bitrouter account --generate-key`.
- *
- * This is a non-interactive operation — the CLI creates the key and
- * sets it as active immediately.
+ * Escape a string for use in a RegExp.
  */
-export async function generateAccount(
-  stateDir: string,
-  homeDir: string,
-): Promise<void> {
-  await runBitrouter(stateDir, homeDir, ["account", "--generate-key"]);
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**
- * Mint a fresh JWT for the given scope via `bitrouter keygen`.
+ * Create an OWS wallet for the plugin to use for JWT signing.
  *
- * The token is signed by the active account key. Each call produces
- * a fresh token (no caching in the CLI).
- *
- * @param scope - "api" or "admin"
- * @param exp - Expiration (e.g. "1h", "24h", "never"). Required for admin scope.
- * @param name - Optional label to save the token locally in bitrouter's key store.
+ * Spawns with `stdio: "inherit"` so `dialoguer::Password` can prompt the
+ * user for a passphrase (it requires a TTY — the env var only works for
+ * subsequent operations like `key sign`). The user can press Enter twice
+ * to accept an empty passphrase.
  */
-export async function mintToken(
+export async function createWallet(
   stateDir: string,
   homeDir: string,
-  scope: "api" | "admin",
-  exp?: string,
-  name?: string,
-): Promise<string> {
-  const args = ["keygen", "--scope", scope];
-  if (exp) args.push("--exp", exp);
-  if (name) args.push("--name", name);
+): Promise<void> {
+  const binaryPath = await getBinaryPath(stateDir);
+  console.log(
+    `\nCreating OWS wallet '${PLUGIN_WALLET_NAME}' for plugin JWT signing.\n` +
+      "You'll be prompted for a passphrase — press Enter twice to skip.\n",
+  );
+  const result = spawnSync(
+    binaryPath,
+    ["--home-dir", homeDir, "wallet", "create", "--name", PLUGIN_WALLET_NAME],
+    {
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        OWS_PASSPHRASE: process.env.OWS_PASSPHRASE ?? "",
+      },
+    },
+  );
 
-  const token = await runBitrouter(stateDir, homeDir, args);
+  if (result.status !== 0) {
+    throw new Error(
+      `bitrouter wallet create --name ${PLUGIN_WALLET_NAME} exited with code ${result.status}` +
+        (result.error ? `: ${result.error.message}` : ""),
+    );
+  }
+}
+
+/**
+ * Mint a fresh JWT via `bitrouter key sign`.
+ *
+ * The token is signed by the named wallet. `key sign` outputs only the
+ * raw JWT to stdout.
+ *
+ * `key sign` prompts interactively for the wallet passphrase via
+ * `dialoguer::Password`, so we inherit stdin/stderr to let the user type
+ * the passphrase while capturing stdout to read the JWT.
+ *
+ * @param wallet - Wallet name to sign with.
+ * @param exp - Expiration duration (e.g. "1h", "24h", "30d").
+ * @param models - Optional model restriction list.
+ */
+export async function signToken(
+  stateDir: string,
+  homeDir: string,
+  wallet?: string,
+  exp?: string,
+  models?: string[],
+): Promise<string> {
+  const walletName = wallet ?? PLUGIN_WALLET_NAME;
+  const args = ["--home-dir", homeDir, "key", "sign", "--wallet", walletName];
+  if (exp) args.push("--exp", exp);
+  if (models && models.length > 0) args.push("--models", models.join(","));
+
+  const binaryPath = await getBinaryPath(stateDir);
+  console.log(
+    "\nMinting a JWT for OpenClaw. Enter the wallet passphrase if prompted.\n",
+  );
+  const result = spawnSync(binaryPath, args, {
+    // Inherit stdin/stderr so the passphrase prompt reaches the user's
+    // terminal; pipe stdout so we can capture the JWT.
+    stdio: ["inherit", "pipe", "inherit"],
+    env: {
+      ...process.env,
+      OWS_PASSPHRASE: process.env.OWS_PASSPHRASE ?? "",
+    },
+    encoding: "utf-8",
+  });
+
+  if (result.status !== 0) {
+    throw new Error(
+      `bitrouter key sign --wallet ${walletName} exited with code ${result.status}` +
+        (result.error ? `: ${result.error.message}` : ""),
+    );
+  }
+
+  const token = (result.stdout ?? "").trim();
   if (!token) {
-    throw new Error(`bitrouter keygen returned empty token (scope=${scope})`);
+    throw new Error(`bitrouter key sign returned empty token`);
   }
   return token;
 }
 
 /**
- * Ensure an active account exists, creating one if needed.
- * Then mint API and admin tokens.
+ * Run `bitrouter auth login [provider]` for provider authentication.
  *
- * This is the main entry point replacing the old ensureAuth().
+ * When provider is specified, authenticates that single provider.
+ * Without provider, runs the interactive multi-provider selection.
+ *
+ * Note: this requires an interactive terminal for most providers.
+ */
+export async function authLogin(
+  stateDir: string,
+  homeDir: string,
+  provider?: string,
+): Promise<string> {
+  const args = ["auth", "login"];
+  if (provider) args.push(provider);
+
+  return runBitrouter(stateDir, homeDir, args);
+}
+
+/**
+ * Get provider auth status via `bitrouter auth status`.
+ */
+export async function authStatus(
+  stateDir: string,
+  homeDir: string,
+): Promise<string> {
+  return runBitrouter(stateDir, homeDir, ["auth", "status"]);
+}
+
+/**
+ * Ensure an OWS wallet exists, creating one if needed.
+ * Then mint an API token for authenticating with the local BitRouter instance.
+ *
+ * This is the main entry point for plugin auth setup.
  */
 export async function ensureAuthViaCli(
   stateDir: string,
   homeDir: string,
-): Promise<{ apiToken: string; adminToken: string }> {
-  // Ensure an account keypair exists.
-  if (!(await hasActiveAccount(stateDir, homeDir))) {
-    await generateAccount(stateDir, homeDir);
+): Promise<{ apiToken: string }> {
+  // Ensure a wallet exists.
+  if (!(await hasWallet(stateDir, homeDir))) {
+    await createWallet(stateDir, homeDir);
   }
 
-  // Mint fresh tokens — cheap local crypto operation.
-  const [apiToken, adminToken] = await Promise.all([
-    mintToken(stateDir, homeDir, "api"),
-    mintToken(stateDir, homeDir, "admin", "24h"),
-  ]);
+  // Mint a fresh API token — uses OWS_PASSPHRASE env for non-interactive signing.
+  const apiToken = await signToken(
+    stateDir,
+    homeDir,
+    PLUGIN_WALLET_NAME,
+    "30d",
+  );
 
-  return { apiToken, adminToken };
+  return { apiToken };
 }

--- a/src/bitrouter-install-tool.ts
+++ b/src/bitrouter-install-tool.ts
@@ -1,0 +1,132 @@
+/**
+ * `bitrouter_install` agent tool — installs or updates the system
+ * `bitrouter` binary using the official installer scripts.
+ *
+ * Unix:    https://bitrouter.ai/install.sh
+ * Windows: https://bitrouter.ai/install.ps1
+ *
+ * Split out from the unified `bitrouter` tool so the model gets a strong
+ * one-line nudge to call this first when other bitrouter_* tools report a
+ * missing binary.
+ */
+
+import { spawn } from "node:child_process";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import { findSystemBinary } from "./binary.js";
+
+const INSTALL_SH_URL = "https://bitrouter.ai/install.sh";
+const INSTALL_PS1_URL = "https://bitrouter.ai/install.ps1";
+
+interface InstallResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runInstaller(timeoutMs = 180_000): Promise<InstallResult> {
+  const isWindows = process.platform === "win32";
+  const command = isWindows ? "powershell.exe" : "sh";
+  const args = isWindows
+    ? [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        `iwr -useb ${INSTALL_PS1_URL} | iex`,
+      ]
+    : ["-c", `curl -fsSL ${INSTALL_SH_URL} | sh`];
+
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { timeout: timeoutMs });
+    let stdout = "";
+    let stderr = "";
+    child.stdout?.on("data", (chunk) => (stdout += chunk.toString()));
+    child.stderr?.on("data", (chunk) => (stderr += chunk.toString()));
+    child.on("error", (err) => {
+      resolve({ stdout, stderr: stderr || err.message, exitCode: 1 });
+    });
+    child.on("close", (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 1 });
+    });
+  });
+}
+
+const InstallToolParameters = {
+  type: "object" as const,
+  properties: {},
+};
+
+/**
+ * Create the `bitrouter_install` agent tool.
+ *
+ * Call this whenever the `bitrouter` tool reports the system binary is
+ * missing, or when the user explicitly asks to install or update BitRouter.
+ */
+export function createBitrouterInstallTool(): AnyAgentTool {
+  return {
+    name: "bitrouter_install",
+    label: "Install BitRouter",
+    displaySummary: "Install or update the system bitrouter binary",
+    description:
+      "Install or update the system `bitrouter` binary by running the official " +
+      "installer script (https://bitrouter.ai/install.sh on Unix, " +
+      "https://bitrouter.ai/install.ps1 on Windows).\n\n" +
+      "Call this tool BEFORE any other `bitrouter` tool if you receive an error " +
+      "that the bitrouter binary is missing from $PATH. Also call it when the " +
+      "user asks to install, reinstall, or update BitRouter.",
+    parameters: InstallToolParameters,
+
+    execute: async (
+      _toolCallId: string,
+      _params: Record<string, never>,
+      signal?: AbortSignal,
+    ): Promise<{
+      content: Array<{ type: string; text: string }>;
+      details: { exitCode: number };
+    }> => {
+      if (signal?.aborted) {
+        return {
+          content: [{ type: "text", text: "Aborted." }],
+          details: { exitCode: 130 },
+        };
+      }
+
+      const before = findSystemBinary();
+      const result = await runInstaller();
+      const after = findSystemBinary();
+
+      const parts: string[] = [];
+      if (result.stdout.trim()) parts.push(result.stdout.trim());
+      if (result.stderr.trim()) {
+        parts.push(`[stderr] ${result.stderr.trim()}`);
+      }
+
+      if (result.exitCode === 0 && after) {
+        parts.push(
+          before
+            ? `BitRouter updated. Binary at: ${after}`
+            : `BitRouter installed. Binary at: ${after}\n` +
+                "If `bitrouter` is still not on $PATH in new shells, " +
+                "add the installer's bin directory to your PATH " +
+                "(commonly `~/.bitrouter/bin` or `~/.cargo/bin`).",
+        );
+      } else if (result.exitCode === 0 && !after) {
+        parts.push(
+          "Installer reported success but `bitrouter` is still not on $PATH. " +
+            "You may need to open a new shell or add the install directory to PATH.",
+        );
+      } else {
+        parts.push(
+          `Installer failed (exit ${result.exitCode}). ` +
+            `See ${INSTALL_SH_URL} or ${INSTALL_PS1_URL} for manual install.`,
+        );
+      }
+
+      return {
+        content: [{ type: "text", text: parts.join("\n") }],
+        details: { exitCode: result.exitCode },
+      };
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}

--- a/src/bitrouter-tool.ts
+++ b/src/bitrouter-tool.ts
@@ -5,12 +5,16 @@
  * The tool validates that every command is in the allowlist before
  * dispatching to the BitRouter binary. Destructive operations (wallet
  * mutations, key creation, auth login, daemon lifecycle) are blocked.
+ *
+ * If the system `bitrouter` binary is missing from $PATH, every command
+ * returns an instructive error pointing the agent to the dedicated
+ * `bitrouter_install` tool.
  */
 
 import { execFile } from "node:child_process";
 import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
 import type { BitrouterState } from "./types.js";
-import { resolveBinaryPath } from "./binary.js";
+import { findSystemBinary } from "./binary.js";
 
 // ── Allowlist ────────────────────────────────────────────────────────
 
@@ -86,12 +90,8 @@ function extractSubcommand(tokens: string[]): string[] {
 
 /**
  * Check whether a tokenised command matches any entry in the allowlist.
- *
- * The command's leading positional tokens must start with an allowed prefix.
- * Extra positional args after the prefix are fine (e.g. "route add model endpoint").
  */
 function isAllowed(tokens: string[]): boolean {
-  // Strip a leading "bitrouter" token if the user included it.
   const effective =
     tokens.length > 0 && tokens[0] === "bitrouter" ? tokens.slice(1) : tokens;
 
@@ -116,19 +116,6 @@ function toCliArgs(tokens: string[]): string[] {
 
 // ── CLI execution ────────────────────────────────────────────────────
 
-/** Cached binary path — resolved once per process. */
-let cachedBinaryPath: string | null = null;
-let cachedStateDir: string | null = null;
-
-async function getBinaryPath(stateDir: string): Promise<string> {
-  if (cachedBinaryPath && cachedStateDir === stateDir) {
-    return cachedBinaryPath;
-  }
-  cachedBinaryPath = await resolveBinaryPath(stateDir);
-  cachedStateDir = stateDir;
-  return cachedBinaryPath;
-}
-
 interface CliResult {
   stdout: string;
   stderr: string;
@@ -136,12 +123,11 @@ interface CliResult {
 }
 
 async function runCli(
-  stateDir: string,
+  binaryPath: string,
   homeDir: string,
   args: string[],
   timeoutMs = 30_000,
 ): Promise<CliResult> {
-  const binaryPath = await getBinaryPath(stateDir);
   return new Promise((resolve) => {
     execFile(
       binaryPath,
@@ -188,13 +174,10 @@ const BitrouterToolParameters = {
 
 /**
  * Create the unified `bitrouter` agent tool.
- *
- * The tool dispatches safe CLI commands to the BitRouter binary and
- * returns the output. Destructive commands are rejected before execution.
  */
 export function createBitrouterTool(
   state: BitrouterState,
-  stateDirRef: { value: string },
+  _stateDirRef: { value: string },
 ): AnyAgentTool {
   return {
     name: "bitrouter",
@@ -203,6 +186,8 @@ export function createBitrouterTool(
     description:
       "Execute BitRouter CLI commands. Use this tool to inspect and manage the BitRouter " +
       "LLM proxy — list models, manage routes, check agent status, view policies, etc.\n\n" +
+      "If the system `bitrouter` binary is missing, this tool returns an error; " +
+      "call the `bitrouter_install` tool first to install it.\n\n" +
       "Available commands:\n  " +
       ALLOWED_COMMANDS_DESCRIPTION +
       "\n\nExamples:\n" +
@@ -260,8 +245,23 @@ export function createBitrouterTool(
         };
       }
 
+      const binaryPath = findSystemBinary();
+      if (!binaryPath) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                "Error: `bitrouter` binary not found on $PATH. " +
+                "Call the `bitrouter_install` tool first to install the system binary.",
+            },
+          ],
+          details: { exitCode: 127 },
+        };
+      }
+
       const args = toCliArgs(tokens);
-      const result = await runCli(stateDirRef.value, state.homeDir, args);
+      const result = await runCli(binaryPath, state.homeDir, args);
 
       const parts: string[] = [];
       if (result.stdout.trim()) {

--- a/src/bitrouter-tool.ts
+++ b/src/bitrouter-tool.ts
@@ -1,0 +1,288 @@
+/**
+ * Unified `bitrouter` agent tool — exposes safe BitRouter CLI subcommands
+ * as a single tool that the LLM can invoke.
+ *
+ * The tool validates that every command is in the allowlist before
+ * dispatching to the BitRouter binary. Destructive operations (wallet
+ * mutations, key creation, auth login, daemon lifecycle) are blocked.
+ */
+
+import { execFile } from "node:child_process";
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import type { BitrouterState } from "./types.js";
+import { resolveBinaryPath } from "./binary.js";
+
+// ── Allowlist ────────────────────────────────────────────────────────
+
+/**
+ * Agent-safe subcommand prefixes. A command is allowed if its positional
+ * tokens (before any `--flag`) start with one of these prefixes.
+ *
+ * Example: "route add mymodel openai:gpt-4o" matches ["route", "add"].
+ */
+const ALLOWED_COMMANDS: string[][] = [
+  ["status"],
+  ["models", "list"],
+  ["tools", "list"],
+  ["tools", "status"],
+  ["route", "list"],
+  ["route", "add"],
+  ["route", "rm"],
+  ["agents", "list"],
+  ["agents", "check"],
+  ["auth", "status"],
+  ["wallet", "list"],
+  ["wallet", "info"],
+  ["key", "list"],
+  ["policy", "list"],
+  ["policy", "show"],
+];
+
+/** Human-readable list of allowed commands for the tool description. */
+export const ALLOWED_COMMANDS_DESCRIPTION = ALLOWED_COMMANDS.map(
+  (tokens) => `bitrouter ${tokens.join(" ")}`,
+).join("\n  ");
+
+// ── Command validation ───────────────────────────────────────────────
+
+/**
+ * Split a raw command string into shell-like tokens.
+ * Handles double-quoted strings but not escapes (good enough for CLI args).
+ */
+function tokenize(input: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (const ch of input) {
+    if (ch === '"') {
+      inQuotes = !inQuotes;
+    } else if (ch === " " && !inQuotes) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+  return tokens;
+}
+
+/**
+ * Extract the subcommand prefix (positional tokens before the first flag).
+ */
+function extractSubcommand(tokens: string[]): string[] {
+  const sub: string[] = [];
+  for (const t of tokens) {
+    if (t.startsWith("-")) break;
+    sub.push(t);
+  }
+  return sub;
+}
+
+/**
+ * Check whether a tokenised command matches any entry in the allowlist.
+ *
+ * The command's leading positional tokens must start with an allowed prefix.
+ * Extra positional args after the prefix are fine (e.g. "route add model endpoint").
+ */
+function isAllowed(tokens: string[]): boolean {
+  // Strip a leading "bitrouter" token if the user included it.
+  const effective =
+    tokens.length > 0 && tokens[0] === "bitrouter" ? tokens.slice(1) : tokens;
+
+  const sub = extractSubcommand(effective);
+  if (sub.length === 0) return false;
+
+  return ALLOWED_COMMANDS.some((allowed) => {
+    if (sub.length < allowed.length) return false;
+    return allowed.every((tok, i) => sub[i] === tok);
+  });
+}
+
+/**
+ * Return the CLI args to pass to the binary (stripping a leading "bitrouter" token).
+ */
+function toCliArgs(tokens: string[]): string[] {
+  if (tokens.length > 0 && tokens[0] === "bitrouter") {
+    return tokens.slice(1);
+  }
+  return tokens;
+}
+
+// ── CLI execution ────────────────────────────────────────────────────
+
+/** Cached binary path — resolved once per process. */
+let cachedBinaryPath: string | null = null;
+let cachedStateDir: string | null = null;
+
+async function getBinaryPath(stateDir: string): Promise<string> {
+  if (cachedBinaryPath && cachedStateDir === stateDir) {
+    return cachedBinaryPath;
+  }
+  cachedBinaryPath = await resolveBinaryPath(stateDir);
+  cachedStateDir = stateDir;
+  return cachedBinaryPath;
+}
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function runCli(
+  stateDir: string,
+  homeDir: string,
+  args: string[],
+  timeoutMs = 30_000,
+): Promise<CliResult> {
+  const binaryPath = await getBinaryPath(stateDir);
+  return new Promise((resolve) => {
+    execFile(
+      binaryPath,
+      ["--home-dir", homeDir, ...args],
+      { timeout: timeoutMs },
+      (err, stdout, stderr) => {
+        if (err && "code" in err && typeof err.code === "number") {
+          resolve({
+            stdout: stdout ?? "",
+            stderr: stderr ?? "",
+            exitCode: err.code,
+          });
+        } else if (err) {
+          resolve({
+            stdout: stdout ?? "",
+            stderr: stderr ?? err.message,
+            exitCode: 1,
+          });
+        } else {
+          resolve({ stdout: stdout ?? "", stderr: stderr ?? "", exitCode: 0 });
+        }
+      },
+    );
+  });
+}
+
+// ── Tool parameters ──────────────────────────────────────────────────
+
+const BitrouterToolParameters = {
+  type: "object" as const,
+  required: ["command"],
+  properties: {
+    command: {
+      type: "string" as const,
+      description:
+        "BitRouter CLI command to execute. Examples: " +
+        '"status", "models list", "route add research openai:gpt-4o", ' +
+        '"route rm research", "wallet list", "policy show --id default".',
+    },
+  },
+};
+
+// ── Tool factory ─────────────────────────────────────────────────────
+
+/**
+ * Create the unified `bitrouter` agent tool.
+ *
+ * The tool dispatches safe CLI commands to the BitRouter binary and
+ * returns the output. Destructive commands are rejected before execution.
+ */
+export function createBitrouterTool(
+  state: BitrouterState,
+  stateDirRef: { value: string },
+): AnyAgentTool {
+  return {
+    name: "bitrouter",
+    label: "BitRouter CLI",
+    displaySummary: "Manage BitRouter routes, models, tools, and policies",
+    description:
+      "Execute BitRouter CLI commands. Use this tool to inspect and manage the BitRouter " +
+      "LLM proxy — list models, manage routes, check agent status, view policies, etc.\n\n" +
+      "Available commands:\n  " +
+      ALLOWED_COMMANDS_DESCRIPTION +
+      "\n\nExamples:\n" +
+      '  command: "status"\n' +
+      '  command: "models list"\n' +
+      '  command: "route add fast openai:gpt-4o-mini"\n' +
+      '  command: "route add research openai:o3 anthropic:claude-opus-4-20250514 --strategy load_balance"\n' +
+      '  command: "route rm fast"\n' +
+      '  command: "wallet list"\n' +
+      '  command: "policy show --id default"',
+    parameters: BitrouterToolParameters,
+
+    execute: async (
+      _toolCallId: string,
+      params: { command?: string },
+      signal?: AbortSignal,
+    ): Promise<{
+      content: Array<{ type: string; text: string }>;
+      details: { exitCode: number };
+    }> => {
+      const raw = (params.command ?? "").trim();
+      if (!raw) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "Error: empty command. Provide a BitRouter CLI command.",
+            },
+          ],
+          details: { exitCode: 1 },
+        };
+      }
+
+      const tokens = tokenize(raw);
+      if (!isAllowed(tokens)) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Error: command "${raw}" is not allowed. ` +
+                "Only read-only and route management commands are permitted.\n\n" +
+                "Allowed commands:\n  " +
+                ALLOWED_COMMANDS_DESCRIPTION,
+            },
+          ],
+          details: { exitCode: 1 },
+        };
+      }
+
+      if (signal?.aborted) {
+        return {
+          content: [{ type: "text", text: "Aborted." }],
+          details: { exitCode: 130 },
+        };
+      }
+
+      const args = toCliArgs(tokens);
+      const result = await runCli(stateDirRef.value, state.homeDir, args);
+
+      const parts: string[] = [];
+      if (result.stdout.trim()) {
+        parts.push(result.stdout.trim());
+      }
+      if (result.stderr.trim()) {
+        parts.push(`[stderr] ${result.stderr.trim()}`);
+      }
+      if (parts.length === 0) {
+        parts.push(
+          result.exitCode === 0
+            ? "Command completed successfully (no output)."
+            : "Command failed with no output.",
+        );
+      }
+
+      return {
+        content: [{ type: "text", text: parts.join("\n") }],
+        details: { exitCode: result.exitCode },
+      };
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}

--- a/src/health.ts
+++ b/src/health.ts
@@ -13,7 +13,13 @@ import type {
   OpenClawPluginApi,
 } from "./types.js";
 import { DEFAULTS } from "./types.js";
-import { refreshRoutes, refreshModels, refreshAgents, refreshTools, refreshSkills } from "./routing.js";
+import {
+  refreshRoutes,
+  refreshModels,
+  refreshAgents,
+  refreshTools,
+  refreshSkills,
+} from "./routing.js";
 import { detectProviders } from "./discovery.js";
 
 // ── Single health check ──────────────────────────────────────────────
@@ -50,11 +56,15 @@ export async function checkHealth(state: BitrouterState): Promise<boolean> {
 /**
  * Start the health check interval. Updates state.healthy and
  * periodically refreshes the routing table.
+ *
+ * @param onRefresh - Optional callback invoked after each tool/skill refresh
+ *                    cycle (e.g. to sync MCP tool bridge registrations).
  */
 export function startHealthCheck(
   api: OpenClawPluginApi,
   config: BitrouterPluginConfig,
   state: BitrouterState,
+  onRefresh?: () => void,
 ): void {
   let tickCount = 0;
   const interval =
@@ -73,6 +83,7 @@ export function startHealthCheck(
       await refreshAgents(state, api);
       await refreshTools(state, api);
       await refreshSkills(state, api);
+      onRefresh?.();
     } else if (!isHealthy && wasHealthy) {
       api.logger.warn("BitRouter health check failed");
     }
@@ -88,6 +99,7 @@ export function startHealthCheck(
       await refreshAgents(state, api);
       await refreshTools(state, api);
       await refreshSkills(state, api);
+      onRefresh?.();
 
       // In auto mode, re-scan for provider changes at the same cadence.
       if (config.mode === "auto") {

--- a/src/http-routes.ts
+++ b/src/http-routes.ts
@@ -26,7 +26,7 @@ async function proxyToBitrouter(
   state: BitrouterState,
   targetPath: string,
   res: ServerResponse,
-  options: { useAdmin?: boolean; method?: string; body?: string } = {},
+  options: { method?: string; body?: string } = {},
 ): Promise<boolean> {
   if (!state.healthy) {
     res.writeHead(503, { "Content-Type": "application/json" });
@@ -35,7 +35,7 @@ async function proxyToBitrouter(
   }
 
   try {
-    const token = options.useAdmin ? state.adminToken : state.apiToken;
+    const token = state.apiToken;
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 30_000);
 
@@ -53,7 +53,8 @@ async function proxyToBitrouter(
     clearTimeout(timeout);
 
     // Forward status and content-type.
-    const contentType = upstream.headers.get("content-type") ?? "application/json";
+    const contentType =
+      upstream.headers.get("content-type") ?? "application/json";
     res.writeHead(upstream.status, { "Content-Type": contentType });
 
     // Stream body.
@@ -92,7 +93,7 @@ function readBody(req: IncomingMessage): Promise<string> {
  */
 export function registerHttpRoutes(
   api: OpenClawPluginApi,
-  state: BitrouterState
+  state: BitrouterState,
 ): void {
   // GET /bitrouter/status — daemon health check
   api.registerHttpRoute({

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ import {
 import { resolveBinaryPath, findSystemBinary } from "./binary.js";
 import { switchAll, restoreModels } from "./switch.js";
 import { createBitrouterTool } from "./bitrouter-tool.js";
+import { createBitrouterInstallTool } from "./bitrouter-install-tool.js";
 import { createMcpToolsBridge } from "./mcp-tools.js";
 
 /**
@@ -116,6 +117,16 @@ export function activate(api: OpenClawPluginApi): void {
     });
   } catch (err) {
     api.logger.error(`Failed to register BitRouter tool: ${err}`);
+  }
+
+  // Dedicated installer tool — split out so the model gets a strong nudge
+  // to call it first when the system binary is missing.
+  try {
+    api.registerTool(createBitrouterInstallTool(), {
+      name: "bitrouter_install",
+    });
+  } catch (err) {
+    api.logger.error(`Failed to register BitRouter install tool: ${err}`);
   }
 
   // ── Register MCP tools bridge ───────────────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ import {
   isOnboardingComplete,
   needsOnboarding,
 } from "./onboarding.js";
-import { resolveBinaryPath } from "./binary.js";
+import { resolveBinaryPath, findSystemBinary } from "./binary.js";
 import { switchAll, restoreModels } from "./switch.js";
 import { createBitrouterTool } from "./bitrouter-tool.js";
 import { createMcpToolsBridge } from "./mcp-tools.js";
@@ -92,7 +92,6 @@ export function activate(api: OpenClawPluginApi): void {
     homeDir: resolveHomeDir(stateDirRef.value),
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
   };
 
@@ -131,293 +130,310 @@ export function activate(api: OpenClawPluginApi): void {
   }
 
   // ── Register CLI subcommands ────────────────────────────────────────
-  try {
-    api.registerCli(
-      ({ program }: { program: unknown }) => {
-        const prog = program as {
-          command(s: string): {
-            description(s: string): {
-              action(fn: () => void | Promise<void>): unknown;
+  //
+  // If the user already has the `bitrouter` binary on PATH, OpenClaw
+  // exposes it as a top-level command. Registering plugin subcommands
+  // would collide with the system binary, so we skip in that case.
+  const systemBinary = findSystemBinary();
+  if (systemBinary) {
+    api.logger.info(
+      `System bitrouter binary found at ${systemBinary} — ` +
+        "skipping plugin CLI registration (use the native CLI directly)",
+    );
+  } else {
+    try {
+      api.registerCli(
+        ({ program }: { program: unknown }) => {
+          const prog = program as {
+            command(s: string): {
+              description(s: string): {
+                action(fn: () => void | Promise<void>): unknown;
+              };
             };
           };
-        };
 
-        // openclaw bitrouter setup — spawn `bitrouter init` interactively
-        prog
-          .command("bitrouter setup")
-          .description(
-            "Set up BitRouter wallet and onboarding via interactive CLI",
-          )
-          .action(async () => {
-            if (!process.stdin.isTTY) {
-              console.log(
-                "\nBitRouter setup requires an interactive terminal.\n" +
-                  "Run this command directly in your terminal (not piped).\n",
+          // openclaw bitrouter setup — spawn `bitrouter init` interactively
+          prog
+            .command("bitrouter setup")
+            .description(
+              "Set up BitRouter wallet and onboarding via interactive CLI",
+            )
+            .action(async () => {
+              if (!process.stdin.isTTY) {
+                console.log(
+                  "\nBitRouter setup requires an interactive terminal.\n" +
+                    "Run this command directly in your terminal (not piped).\n",
+                );
+                return;
+              }
+
+              let binaryPath: string;
+              try {
+                binaryPath = await resolveBinaryPath(stateDirRef.value);
+              } catch (err) {
+                console.error(`\nFailed to resolve BitRouter binary: ${err}\n`);
+                return;
+              }
+
+              console.log("\nLaunching BitRouter onboarding wizard...\n");
+              const result = spawnSync(
+                binaryPath,
+                ["--home-dir", state.homeDir, "init"],
+                {
+                  stdio: "inherit",
+                },
               );
-              return;
-            }
 
-            let binaryPath: string;
-            try {
-              binaryPath = await resolveBinaryPath(stateDirRef.value);
-            } catch (err) {
-              console.error(`\nFailed to resolve BitRouter binary: ${err}\n`);
-              return;
-            }
+              if (result.status !== 0) {
+                console.error(
+                  `\nBitRouter init exited with code ${result.status}.` +
+                    (result.error ? ` Error: ${result.error.message}` : "") +
+                    "\n",
+                );
+                return;
+              }
 
-            console.log("\nLaunching BitRouter onboarding wizard...\n");
-            const result = spawnSync(
-              binaryPath,
-              ["--home-dir", state.homeDir, "init"],
-              {
-                stdio: "inherit",
-              },
-            );
+              // Read onboarding state after completion.
+              const onboarding = loadOnboardingState(state.homeDir);
+              if (onboarding && isOnboardingComplete(onboarding)) {
+                console.log(
+                  `\nOnboarding complete (${onboarding.status}).` +
+                    "\nRestart the gateway to activate: openclaw gateway restart\n",
+                );
+              } else {
+                console.log(
+                  "\nOnboarding did not complete. You can re-run: openclaw bitrouter setup\n",
+                );
+              }
+            });
 
-            if (result.status !== 0) {
-              console.error(
-                `\nBitRouter init exited with code ${result.status}.` +
-                  (result.error ? ` Error: ${result.error.message}` : "") +
-                  "\n",
-              );
-              return;
-            }
+          // openclaw bitrouter wallet — show wallet/onboarding info
+          prog
+            .command("bitrouter wallet")
+            .description("Show BitRouter wallet and onboarding state")
+            .action(() => {
+              const onboarding = loadOnboardingState(state.homeDir);
+              if (!onboarding) {
+                console.log(
+                  "\nNo onboarding state found. Run: openclaw bitrouter setup\n",
+                );
+                return;
+              }
+              console.log("\nBitRouter Onboarding State:");
+              console.log(JSON.stringify(onboarding, null, 2));
+              console.log();
+            });
 
-            // Read onboarding state after completion.
-            const onboarding = loadOnboardingState(state.homeDir);
-            if (onboarding && isOnboardingComplete(onboarding)) {
-              console.log(
-                `\nOnboarding complete (${onboarding.status}).` +
-                  "\nRestart the gateway to activate: openclaw gateway restart\n",
-              );
-            } else {
-              console.log(
-                "\nOnboarding did not complete. You can re-run: openclaw bitrouter setup\n",
-              );
-            }
-          });
+          // openclaw bitrouter status — overview of plugin state
+          prog
+            .command("bitrouter status")
+            .description(
+              "Show BitRouter plugin status, daemon health, and wallet info",
+            )
+            .action(() => {
+              const sections: string[] = ["\nBitRouter Status:"];
 
-        // openclaw bitrouter wallet — show wallet/onboarding info
-        prog
-          .command("bitrouter wallet")
-          .description("Show BitRouter wallet and onboarding state")
-          .action(() => {
-            const onboarding = loadOnboardingState(state.homeDir);
-            if (!onboarding) {
-              console.log(
-                "\nNo onboarding state found. Run: openclaw bitrouter setup\n",
-              );
-              return;
-            }
-            console.log("\nBitRouter Onboarding State:");
-            console.log(JSON.stringify(onboarding, null, 2));
-            console.log();
-          });
-
-        // openclaw bitrouter status — overview of plugin state
-        prog
-          .command("bitrouter status")
-          .description(
-            "Show BitRouter plugin status, daemon health, and wallet info",
-          )
-          .action(() => {
-            const sections: string[] = ["\nBitRouter Status:"];
-
-            // Onboarding
-            const onboarding = loadOnboardingState(state.homeDir);
-            sections.push(`  Onboarding: ${onboarding?.status ?? "not found"}`);
-
-            // Daemon health
-            sections.push(
-              `  Daemon: ${state.healthy ? "healthy" : "unhealthy"}`,
-            );
-            sections.push(`  URL: ${state.baseUrl}`);
-
-            // Routes
-            sections.push(`  Routes: ${state.knownRoutes.length} known`);
-            for (const r of state.knownRoutes) {
-              sections.push(`    ${r.model} → ${r.provider} (${r.protocol})`);
-            }
-
-            // Agents
-            sections.push(`  A2A Agents: ${state.knownAgents.length} upstream`);
-            for (const a of state.knownAgents) {
-              const skills =
-                a.skills.length > 0
-                  ? ` (${a.skills.map((s) => s.name).join(", ")})`
-                  : "";
-              sections.push(`    ${a.id}${skills}`);
-            }
-
-            // Tools & Skills
-            const mcpTools = state.knownTools.filter(
-              (t) => t.provider !== "skill",
-            );
-            const skillTools = state.knownTools.filter(
-              (t) => t.provider === "skill",
-            );
-            sections.push(
-              `  MCP Tools: ${mcpTools.length}, Skills: ${skillTools.length}`,
-            );
-
-            // Wallet info
-            if (onboarding?.wallet_address) {
-              sections.push(`  Wallet: ${onboarding.wallet_address}`);
-            }
-            if (onboarding?.swig_id) {
-              sections.push(`  Swig ID: ${onboarding.swig_id}`);
-            }
-            if (onboarding?.agent_wallets?.length) {
+              // Onboarding
+              const onboarding = loadOnboardingState(state.homeDir);
               sections.push(
-                `  Agent wallets: ${onboarding.agent_wallets.length}`,
+                `  Onboarding: ${onboarding?.status ?? "not found"}`,
               );
-              for (const aw of onboarding.agent_wallets) {
+
+              // Daemon health
+              sections.push(
+                `  Daemon: ${state.healthy ? "healthy" : "unhealthy"}`,
+              );
+              sections.push(`  URL: ${state.baseUrl}`);
+
+              // Routes
+              sections.push(`  Routes: ${state.knownRoutes.length} known`);
+              for (const r of state.knownRoutes) {
+                sections.push(`    ${r.model} → ${r.provider} (${r.protocol})`);
+              }
+
+              // Agents
+              sections.push(
+                `  A2A Agents: ${state.knownAgents.length} upstream`,
+              );
+              for (const a of state.knownAgents) {
+                const skills =
+                  a.skills.length > 0
+                    ? ` (${a.skills.map((s) => s.name).join(", ")})`
+                    : "";
+                sections.push(`    ${a.id}${skills}`);
+              }
+
+              // Tools & Skills
+              const mcpTools = state.knownTools.filter(
+                (t) => t.provider !== "skill",
+              );
+              const skillTools = state.knownTools.filter(
+                (t) => t.provider === "skill",
+              );
+              sections.push(
+                `  MCP Tools: ${mcpTools.length}, Skills: ${skillTools.length}`,
+              );
+
+              // Wallet info
+              if (onboarding?.wallet_address) {
+                sections.push(`  Wallet: ${onboarding.wallet_address}`);
+              }
+              if (onboarding?.swig_id) {
+                sections.push(`  Swig ID: ${onboarding.swig_id}`);
+              }
+              if (onboarding?.agent_wallets?.length) {
                 sections.push(
-                  `    ${aw.label}: ${aw.address} (role ${aw.role_id})`,
+                  `  Agent wallets: ${onboarding.agent_wallets.length}`,
                 );
+                for (const aw of onboarding.agent_wallets) {
+                  sections.push(
+                    `    ${aw.label}: ${aw.address} (role ${aw.role_id})`,
+                  );
+                }
               }
-            }
 
-            console.log(sections.join("\n") + "\n");
-          });
+              console.log(sections.join("\n") + "\n");
+            });
 
-        // openclaw bitrouter switch-all — rewrite agent models to bitrouter/
-        prog
-          .command("bitrouter switch-all")
-          .description(
-            "Rewrite all agent model configs to route through BitRouter",
-          )
-          .action(async () => {
-            const result = await switchAll(api, config, state);
-            if (result.error) {
-              console.error(`\nError: ${result.error}\n`);
-              return;
-            }
-            console.log("\nSwitched agent models to BitRouter:");
-            for (const line of result.changes) {
-              console.log(line);
-            }
-            console.log(
-              "\nRestart the gateway to apply: openclaw gateway restart\n",
-            );
-          });
-
-        // openclaw bitrouter restore-models — restore original agent models
-        prog
-          .command("bitrouter restore-models")
-          .description("Restore agent model configs to their original values")
-          .action(async () => {
-            const result = await restoreModels(api, config);
-            if (result.error) {
-              console.error(`\nError: ${result.error}\n`);
-              return;
-            }
-            console.log("\nRestored original agent models:");
-            for (const line of result.changes) {
-              console.log(line);
-            }
-            console.log(
-              "\nRestart the gateway to apply: openclaw gateway restart\n",
-            );
-          });
-
-        // openclaw bitrouter agents — list upstream A2A agents
-        prog
-          .command("bitrouter agents")
-          .description("List upstream A2A agents proxied through BitRouter")
-          .action(async () => {
-            if (!state.healthy) {
+          // openclaw bitrouter switch-all — rewrite agent models to bitrouter/
+          prog
+            .command("bitrouter switch-all")
+            .description(
+              "Rewrite all agent model configs to route through BitRouter",
+            )
+            .action(async () => {
+              const result = await switchAll(api, config, state);
+              if (result.error) {
+                console.error(`\nError: ${result.error}\n`);
+                return;
+              }
+              console.log("\nSwitched agent models to BitRouter:");
+              for (const line of result.changes) {
+                console.log(line);
+              }
               console.log(
-                "\nBitRouter is not healthy. Start the gateway first.\n",
+                "\nRestart the gateway to apply: openclaw gateway restart\n",
               );
-              return;
-            }
-            await refreshAgents(state, api);
-            if (state.knownAgents.length === 0) {
-              console.log("\nNo upstream A2A agents configured.\n");
+            });
+
+          // openclaw bitrouter restore-models — restore original agent models
+          prog
+            .command("bitrouter restore-models")
+            .description("Restore agent model configs to their original values")
+            .action(async () => {
+              const result = await restoreModels(api, config);
+              if (result.error) {
+                console.error(`\nError: ${result.error}\n`);
+                return;
+              }
+              console.log("\nRestored original agent models:");
+              for (const line of result.changes) {
+                console.log(line);
+              }
               console.log(
-                "Configure agents in openclaw.json under plugins.entries.bitrouter.config.a2aAgents\n",
+                "\nRestart the gateway to apply: openclaw gateway restart\n",
               );
-              return;
-            }
-            console.log(
-              `\nUpstream A2A Agents (${state.knownAgents.length}):\n`,
-            );
-            for (const agent of state.knownAgents) {
-              const streaming = agent.streaming ? " [streaming]" : "";
-              console.log(`  ${agent.id}${streaming}`);
-              if (agent.description) console.log(`    ${agent.description}`);
-              if (agent.skills.length > 0) {
+            });
+
+          // openclaw bitrouter agents — list upstream A2A agents
+          prog
+            .command("bitrouter agents")
+            .description("List upstream A2A agents proxied through BitRouter")
+            .action(async () => {
+              if (!state.healthy) {
                 console.log(
-                  `    Skills: ${agent.skills.map((s) => s.name).join(", ")}`,
+                  "\nBitRouter is not healthy. Start the gateway first.\n",
                 );
+                return;
               }
-              if (agent.input_modes.length > 0) {
+              await refreshAgents(state, api);
+              if (state.knownAgents.length === 0) {
+                console.log("\nNo upstream A2A agents configured.\n");
                 console.log(
-                  `    Input: ${agent.input_modes.join(", ")}  Output: ${agent.output_modes.join(", ")}`,
+                  "Configure agents in openclaw.json under plugins.entries.bitrouter.config.a2aAgents\n",
                 );
+                return;
               }
-            }
-            console.log();
-          });
-
-        // openclaw bitrouter tools — list MCP tools and skills
-        prog
-          .command("bitrouter tools")
-          .description(
-            "List MCP tools and registered skills available through BitRouter",
-          )
-          .action(async () => {
-            if (!state.healthy) {
               console.log(
-                "\nBitRouter is not healthy. Start the gateway first.\n",
+                `\nUpstream A2A Agents (${state.knownAgents.length}):\n`,
               );
-              return;
-            }
-            await refreshTools(state, api);
-            await refreshSkills(state, api);
-
-            if (state.knownTools.length === 0) {
-              console.log("\nNo tools or skills registered.\n");
-              console.log(
-                "Configure MCP servers in openclaw.json under plugins.entries.bitrouter.config.mcpServers",
-              );
-              console.log(
-                "Configure skills under plugins.entries.bitrouter.config.skills\n",
-              );
-              return;
-            }
-
-            const mcpTools = state.knownTools.filter(
-              (t) => t.provider !== "skill",
-            );
-            const skillEntries = state.knownTools.filter(
-              (t) => t.provider === "skill",
-            );
-
-            if (mcpTools.length > 0) {
-              console.log(`\nMCP Tools (${mcpTools.length}):\n`);
-              for (const tool of mcpTools) {
-                console.log(`  ${tool.id} [${tool.provider}]`);
-                if (tool.description) console.log(`    ${tool.description}`);
+              for (const agent of state.knownAgents) {
+                const streaming = agent.streaming ? " [streaming]" : "";
+                console.log(`  ${agent.id}${streaming}`);
+                if (agent.description) console.log(`    ${agent.description}`);
+                if (agent.skills.length > 0) {
+                  console.log(
+                    `    Skills: ${agent.skills.map((s) => s.name).join(", ")}`,
+                  );
+                }
+                if (agent.input_modes.length > 0) {
+                  console.log(
+                    `    Input: ${agent.input_modes.join(", ")}  Output: ${agent.output_modes.join(", ")}`,
+                  );
+                }
               }
-            }
+              console.log();
+            });
 
-            if (skillEntries.length > 0) {
-              console.log(`\nSkills (${skillEntries.length}):\n`);
-              for (const skill of skillEntries) {
-                console.log(`  ${skill.id}`);
-                if (skill.description) console.log(`    ${skill.description}`);
+          // openclaw bitrouter tools — list MCP tools and skills
+          prog
+            .command("bitrouter tools")
+            .description(
+              "List MCP tools and registered skills available through BitRouter",
+            )
+            .action(async () => {
+              if (!state.healthy) {
+                console.log(
+                  "\nBitRouter is not healthy. Start the gateway first.\n",
+                );
+                return;
               }
-            }
+              await refreshTools(state, api);
+              await refreshSkills(state, api);
 
-            console.log();
-          });
-      },
-      { commands: ["bitrouter"] },
-    );
-  } catch (err) {
-    api.logger.warn(`Failed to register bitrouter CLI commands: ${err}`);
+              if (state.knownTools.length === 0) {
+                console.log("\nNo tools or skills registered.\n");
+                console.log(
+                  "Configure MCP servers in openclaw.json under plugins.entries.bitrouter.config.mcpServers",
+                );
+                console.log(
+                  "Configure skills under plugins.entries.bitrouter.config.skills\n",
+                );
+                return;
+              }
+
+              const mcpTools = state.knownTools.filter(
+                (t) => t.provider !== "skill",
+              );
+              const skillEntries = state.knownTools.filter(
+                (t) => t.provider === "skill",
+              );
+
+              if (mcpTools.length > 0) {
+                console.log(`\nMCP Tools (${mcpTools.length}):\n`);
+                for (const tool of mcpTools) {
+                  console.log(`  ${tool.id} [${tool.provider}]`);
+                  if (tool.description) console.log(`    ${tool.description}`);
+                }
+              }
+
+              if (skillEntries.length > 0) {
+                console.log(`\nSkills (${skillEntries.length}):\n`);
+                for (const skill of skillEntries) {
+                  console.log(`  ${skill.id}`);
+                  if (skill.description)
+                    console.log(`    ${skill.description}`);
+                }
+              }
+
+              console.log();
+            });
+        },
+        { commands: ["bitrouter"] },
+      );
+    } catch (err) {
+      api.logger.warn(`Failed to register bitrouter CLI commands: ${err}`);
+    }
   }
 
   // ── Check if setup has been completed ────────────────────────────

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,12 +43,23 @@ import { DEFAULTS } from "./types.js";
 import { resolveHomeDir } from "./config.js";
 import { registerBitrouterService } from "./service.js";
 import { registerBitrouterProvider } from "./provider.js";
-import { registerModelInterceptor, refreshAgents, refreshTools, refreshSkills } from "./routing.js";
+import {
+  registerModelInterceptor,
+  refreshAgents,
+  refreshTools,
+  refreshSkills,
+} from "./routing.js";
 import { registerPromptContext } from "./prompt-context.js";
 import { registerHttpRoutes } from "./http-routes.js";
-import { loadOnboardingState, isOnboardingComplete, needsOnboarding } from "./onboarding.js";
+import {
+  loadOnboardingState,
+  isOnboardingComplete,
+  needsOnboarding,
+} from "./onboarding.js";
 import { resolveBinaryPath } from "./binary.js";
 import { switchAll, restoreModels } from "./switch.js";
+import { createBitrouterTool } from "./bitrouter-tool.js";
+import { createMcpToolsBridge } from "./mcp-tools.js";
 
 /**
  * Plugin activation — called by OpenClaw when the plugin is loaded.
@@ -63,7 +74,9 @@ export function activate(api: OpenClawPluginApi): void {
 
   // Mutable ref for stateDir — set when the service's start(ctx) fires.
   // Fallback covers provider/CLI registration that happens before service start.
-  const stateDirRef = { value: `${process.env.HOME}/.openclaw/plugins/bitrouter` };
+  const stateDirRef = {
+    value: `${process.env.HOME}/.openclaw/plugins/bitrouter`,
+  };
 
   // Shared mutable state — passed by reference to all sub-modules.
   const state: BitrouterState = {
@@ -94,6 +107,29 @@ export function activate(api: OpenClawPluginApi): void {
     api.logger.error(`Failed to register BitRouter provider: ${err}`);
   }
 
+  // ── Register the unified `bitrouter` agent tool ─────────────────────
+  //
+  // One required tool that dispatches safe CLI subcommands. The LLM uses
+  // this to inspect routes, manage dynamic routes, list models/tools, etc.
+  try {
+    api.registerTool(createBitrouterTool(state, stateDirRef), {
+      name: "bitrouter",
+    });
+  } catch (err) {
+    api.logger.error(`Failed to register BitRouter tool: ${err}`);
+  }
+
+  // ── Register MCP tools bridge ───────────────────────────────────────
+  //
+  // Exposes BitRouter's upstream MCP tools as optional OpenClaw agent tools.
+  // Tools are discovered lazily once BitRouter is healthy.
+  const mcpBridge = createMcpToolsBridge(api, state);
+  try {
+    mcpBridge.registerInitialTools();
+  } catch (err) {
+    api.logger.warn(`Failed to register initial MCP tools: ${err}`);
+  }
+
   // ── Register CLI subcommands ────────────────────────────────────────
   try {
     api.registerCli(
@@ -109,12 +145,14 @@ export function activate(api: OpenClawPluginApi): void {
         // openclaw bitrouter setup — spawn `bitrouter init` interactively
         prog
           .command("bitrouter setup")
-          .description("Set up BitRouter wallet and onboarding via interactive CLI")
+          .description(
+            "Set up BitRouter wallet and onboarding via interactive CLI",
+          )
           .action(async () => {
             if (!process.stdin.isTTY) {
               console.log(
                 "\nBitRouter setup requires an interactive terminal.\n" +
-                  "Run this command directly in your terminal (not piped).\n"
+                  "Run this command directly in your terminal (not piped).\n",
               );
               return;
             }
@@ -128,15 +166,19 @@ export function activate(api: OpenClawPluginApi): void {
             }
 
             console.log("\nLaunching BitRouter onboarding wizard...\n");
-            const result = spawnSync(binaryPath, ["--home-dir", state.homeDir, "init"], {
-              stdio: "inherit",
-            });
+            const result = spawnSync(
+              binaryPath,
+              ["--home-dir", state.homeDir, "init"],
+              {
+                stdio: "inherit",
+              },
+            );
 
             if (result.status !== 0) {
               console.error(
                 `\nBitRouter init exited with code ${result.status}.` +
                   (result.error ? ` Error: ${result.error.message}` : "") +
-                  "\n"
+                  "\n",
               );
               return;
             }
@@ -146,11 +188,11 @@ export function activate(api: OpenClawPluginApi): void {
             if (onboarding && isOnboardingComplete(onboarding)) {
               console.log(
                 `\nOnboarding complete (${onboarding.status}).` +
-                  "\nRestart the gateway to activate: openclaw gateway restart\n"
+                  "\nRestart the gateway to activate: openclaw gateway restart\n",
               );
             } else {
               console.log(
-                "\nOnboarding did not complete. You can re-run: openclaw bitrouter setup\n"
+                "\nOnboarding did not complete. You can re-run: openclaw bitrouter setup\n",
               );
             }
           });
@@ -162,7 +204,9 @@ export function activate(api: OpenClawPluginApi): void {
           .action(() => {
             const onboarding = loadOnboardingState(state.homeDir);
             if (!onboarding) {
-              console.log("\nNo onboarding state found. Run: openclaw bitrouter setup\n");
+              console.log(
+                "\nNo onboarding state found. Run: openclaw bitrouter setup\n",
+              );
               return;
             }
             console.log("\nBitRouter Onboarding State:");
@@ -173,18 +217,20 @@ export function activate(api: OpenClawPluginApi): void {
         // openclaw bitrouter status — overview of plugin state
         prog
           .command("bitrouter status")
-          .description("Show BitRouter plugin status, daemon health, and wallet info")
+          .description(
+            "Show BitRouter plugin status, daemon health, and wallet info",
+          )
           .action(() => {
             const sections: string[] = ["\nBitRouter Status:"];
 
             // Onboarding
             const onboarding = loadOnboardingState(state.homeDir);
-            sections.push(
-              `  Onboarding: ${onboarding?.status ?? "not found"}`
-            );
+            sections.push(`  Onboarding: ${onboarding?.status ?? "not found"}`);
 
             // Daemon health
-            sections.push(`  Daemon: ${state.healthy ? "healthy" : "unhealthy"}`);
+            sections.push(
+              `  Daemon: ${state.healthy ? "healthy" : "unhealthy"}`,
+            );
             sections.push(`  URL: ${state.baseUrl}`);
 
             // Routes
@@ -196,16 +242,23 @@ export function activate(api: OpenClawPluginApi): void {
             // Agents
             sections.push(`  A2A Agents: ${state.knownAgents.length} upstream`);
             for (const a of state.knownAgents) {
-              const skills = a.skills.length > 0
-                ? ` (${a.skills.map((s) => s.name).join(", ")})`
-                : "";
+              const skills =
+                a.skills.length > 0
+                  ? ` (${a.skills.map((s) => s.name).join(", ")})`
+                  : "";
               sections.push(`    ${a.id}${skills}`);
             }
 
             // Tools & Skills
-            const mcpTools = state.knownTools.filter((t) => t.provider !== "skill");
-            const skillTools = state.knownTools.filter((t) => t.provider === "skill");
-            sections.push(`  MCP Tools: ${mcpTools.length}, Skills: ${skillTools.length}`);
+            const mcpTools = state.knownTools.filter(
+              (t) => t.provider !== "skill",
+            );
+            const skillTools = state.knownTools.filter(
+              (t) => t.provider === "skill",
+            );
+            sections.push(
+              `  MCP Tools: ${mcpTools.length}, Skills: ${skillTools.length}`,
+            );
 
             // Wallet info
             if (onboarding?.wallet_address) {
@@ -215,9 +268,13 @@ export function activate(api: OpenClawPluginApi): void {
               sections.push(`  Swig ID: ${onboarding.swig_id}`);
             }
             if (onboarding?.agent_wallets?.length) {
-              sections.push(`  Agent wallets: ${onboarding.agent_wallets.length}`);
+              sections.push(
+                `  Agent wallets: ${onboarding.agent_wallets.length}`,
+              );
               for (const aw of onboarding.agent_wallets) {
-                sections.push(`    ${aw.label}: ${aw.address} (role ${aw.role_id})`);
+                sections.push(
+                  `    ${aw.label}: ${aw.address} (role ${aw.role_id})`,
+                );
               }
             }
 
@@ -227,7 +284,9 @@ export function activate(api: OpenClawPluginApi): void {
         // openclaw bitrouter switch-all — rewrite agent models to bitrouter/
         prog
           .command("bitrouter switch-all")
-          .description("Rewrite all agent model configs to route through BitRouter")
+          .description(
+            "Rewrite all agent model configs to route through BitRouter",
+          )
           .action(async () => {
             const result = await switchAll(api, config, state);
             if (result.error) {
@@ -238,7 +297,9 @@ export function activate(api: OpenClawPluginApi): void {
             for (const line of result.changes) {
               console.log(line);
             }
-            console.log("\nRestart the gateway to apply: openclaw gateway restart\n");
+            console.log(
+              "\nRestart the gateway to apply: openclaw gateway restart\n",
+            );
           });
 
         // openclaw bitrouter restore-models — restore original agent models
@@ -255,7 +316,9 @@ export function activate(api: OpenClawPluginApi): void {
             for (const line of result.changes) {
               console.log(line);
             }
-            console.log("\nRestart the gateway to apply: openclaw gateway restart\n");
+            console.log(
+              "\nRestart the gateway to apply: openclaw gateway restart\n",
+            );
           });
 
         // openclaw bitrouter agents — list upstream A2A agents
@@ -264,25 +327,35 @@ export function activate(api: OpenClawPluginApi): void {
           .description("List upstream A2A agents proxied through BitRouter")
           .action(async () => {
             if (!state.healthy) {
-              console.log("\nBitRouter is not healthy. Start the gateway first.\n");
+              console.log(
+                "\nBitRouter is not healthy. Start the gateway first.\n",
+              );
               return;
             }
             await refreshAgents(state, api);
             if (state.knownAgents.length === 0) {
               console.log("\nNo upstream A2A agents configured.\n");
-              console.log("Configure agents in openclaw.json under plugins.entries.bitrouter.config.a2aAgents\n");
+              console.log(
+                "Configure agents in openclaw.json under plugins.entries.bitrouter.config.a2aAgents\n",
+              );
               return;
             }
-            console.log(`\nUpstream A2A Agents (${state.knownAgents.length}):\n`);
+            console.log(
+              `\nUpstream A2A Agents (${state.knownAgents.length}):\n`,
+            );
             for (const agent of state.knownAgents) {
               const streaming = agent.streaming ? " [streaming]" : "";
               console.log(`  ${agent.id}${streaming}`);
               if (agent.description) console.log(`    ${agent.description}`);
               if (agent.skills.length > 0) {
-                console.log(`    Skills: ${agent.skills.map((s) => s.name).join(", ")}`);
+                console.log(
+                  `    Skills: ${agent.skills.map((s) => s.name).join(", ")}`,
+                );
               }
               if (agent.input_modes.length > 0) {
-                console.log(`    Input: ${agent.input_modes.join(", ")}  Output: ${agent.output_modes.join(", ")}`);
+                console.log(
+                  `    Input: ${agent.input_modes.join(", ")}  Output: ${agent.output_modes.join(", ")}`,
+                );
               }
             }
             console.log();
@@ -291,10 +364,14 @@ export function activate(api: OpenClawPluginApi): void {
         // openclaw bitrouter tools — list MCP tools and skills
         prog
           .command("bitrouter tools")
-          .description("List MCP tools and registered skills available through BitRouter")
+          .description(
+            "List MCP tools and registered skills available through BitRouter",
+          )
           .action(async () => {
             if (!state.healthy) {
-              console.log("\nBitRouter is not healthy. Start the gateway first.\n");
+              console.log(
+                "\nBitRouter is not healthy. Start the gateway first.\n",
+              );
               return;
             }
             await refreshTools(state, api);
@@ -302,13 +379,21 @@ export function activate(api: OpenClawPluginApi): void {
 
             if (state.knownTools.length === 0) {
               console.log("\nNo tools or skills registered.\n");
-              console.log("Configure MCP servers in openclaw.json under plugins.entries.bitrouter.config.mcpServers");
-              console.log("Configure skills under plugins.entries.bitrouter.config.skills\n");
+              console.log(
+                "Configure MCP servers in openclaw.json under plugins.entries.bitrouter.config.mcpServers",
+              );
+              console.log(
+                "Configure skills under plugins.entries.bitrouter.config.skills\n",
+              );
               return;
             }
 
-            const mcpTools = state.knownTools.filter((t) => t.provider !== "skill");
-            const skillEntries = state.knownTools.filter((t) => t.provider === "skill");
+            const mcpTools = state.knownTools.filter(
+              (t) => t.provider !== "skill",
+            );
+            const skillEntries = state.knownTools.filter(
+              (t) => t.provider === "skill",
+            );
 
             if (mcpTools.length > 0) {
               console.log(`\nMCP Tools (${mcpTools.length}):\n`);
@@ -329,7 +414,7 @@ export function activate(api: OpenClawPluginApi): void {
             console.log();
           });
       },
-      { commands: ["bitrouter"] }
+      { commands: ["bitrouter"] },
     );
   } catch (err) {
     api.logger.warn(`Failed to register bitrouter CLI commands: ${err}`);
@@ -349,15 +434,19 @@ export function activate(api: OpenClawPluginApi): void {
         config.solanaRpcUrl = onboarding.rpc_url;
       }
       state.onboardingState = onboarding;
-      api.logger.info("BitRouter activating in cloud mode (onboarding completed)");
+      api.logger.info(
+        "BitRouter activating in cloud mode (onboarding completed)",
+      );
     } else if (onboarding && onboarding.status === "completed_byok") {
       // BYOK onboarding completed via Rust CLI — fall through to auto-detect.
       state.onboardingState = onboarding;
-      api.logger.info("BitRouter BYOK onboarding detected, using auto-detect flow");
+      api.logger.info(
+        "BitRouter BYOK onboarding detected, using auto-detect flow",
+      );
     } else {
       if (onboarding && needsOnboarding(onboarding)) {
         api.logger.info(
-          "BitRouter onboarding not complete. Run: openclaw bitrouter setup"
+          "BitRouter onboarding not complete. Run: openclaw bitrouter setup",
         );
       }
     }
@@ -368,7 +457,7 @@ export function activate(api: OpenClawPluginApi): void {
     if (!config.mode) {
       config.mode = "auto";
       api.logger.info(
-        "BitRouter activating in auto mode — provider detection deferred to discovery phase"
+        "BitRouter activating in auto mode — provider detection deferred to discovery phase",
       );
     }
   }
@@ -377,7 +466,9 @@ export function activate(api: OpenClawPluginApi): void {
 
   // Register the daemon service (spawn/stop bitrouter).
   try {
-    registerBitrouterService(api, config, state, stateDirRef);
+    registerBitrouterService(api, config, state, stateDirRef, () =>
+      mcpBridge.refresh(),
+    );
   } catch (err) {
     api.logger.error(`Failed to register BitRouter service: ${err}`);
     // Continue — the user may run BitRouter externally.
@@ -406,12 +497,12 @@ export function activate(api: OpenClawPluginApi): void {
 
   if (config.mode === "auto") {
     api.logger.info(
-      `BitRouter plugin activated in auto mode (${state.baseUrl}, use 'openclaw bitrouter switch-all' to route all models)`
+      `BitRouter plugin activated in auto mode (${state.baseUrl}, use 'openclaw bitrouter switch-all' to route all models)`,
     );
   } else {
     const upstream = config.byok?.upstreamProvider ?? "unknown";
     api.logger.info(
-      `BitRouter plugin activated (${state.baseUrl}, mode=${config.mode}, upstream=${upstream})`
+      `BitRouter plugin activated (${state.baseUrl}, mode=${config.mode}, upstream=${upstream})`,
     );
   }
 
@@ -423,7 +514,10 @@ export function activate(api: OpenClawPluginApi): void {
   // overhead for two localhost calls).
   try {
     const healthResult = spawnSync("curl", [
-      "-s", "--max-time", "1", `${state.baseUrl}/health`,
+      "-s",
+      "--max-time",
+      "1",
+      `${state.baseUrl}/health`,
     ]);
     if (healthResult.status === 0) {
       const health = JSON.parse(healthResult.stdout.toString());
@@ -431,13 +525,16 @@ export function activate(api: OpenClawPluginApi): void {
         state.healthy = true;
 
         const routesResult = spawnSync("curl", [
-          "-s", "--max-time", "2", `${state.baseUrl}/v1/routes`,
+          "-s",
+          "--max-time",
+          "2",
+          `${state.baseUrl}/v1/routes`,
         ]);
         if (routesResult.status === 0) {
           const body = JSON.parse(routesResult.stdout.toString());
           state.knownRoutes = body.routes ?? [];
           api.logger.info(
-            `Loaded ${state.knownRoutes.length} route(s) from BitRouter (sync probe)`
+            `Loaded ${state.knownRoutes.length} route(s) from BitRouter (sync probe)`,
           );
         }
       }

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,0 +1,230 @@
+/**
+ * MCP Tools Bridge — exposes BitRouter's upstream MCP tools as optional
+ * OpenClaw agent tools.
+ *
+ * On each health-check refresh cycle, we fetch GET /v1/tools from
+ * BitRouter and register any new tools (or unregister removed ones)
+ * as optional OpenClaw agent tools. Tool execution is proxied via
+ * BitRouter's MCP gateway (POST /mcp with JSON-RPC `tools/call`).
+ */
+
+import type { AnyAgentTool } from "openclaw/plugin-sdk/plugin-entry";
+import type { BitrouterState, OpenClawPluginApi, ToolInfo } from "./types.js";
+
+// ── Tool name helpers ────────────────────────────────────────────────
+
+/**
+ * Namespace a BitRouter tool name for OpenClaw registration.
+ * Replaces non-alphanumeric chars with underscores for tool name compatibility.
+ */
+function toOpenClawToolName(toolId: string): string {
+  return `bitrouter_${toolId.replace(/[^a-zA-Z0-9_]/g, "_")}`;
+}
+
+// ── JSON-RPC proxy ───────────────────────────────────────────────────
+
+/**
+ * Call a tool via BitRouter's MCP JSON-RPC gateway.
+ */
+async function callMcpTool(
+  state: BitrouterState,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<{ content: string; isError: boolean }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60_000);
+
+  try {
+    const res = await fetch(`${state.baseUrl}/mcp`, {
+      method: "POST",
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...(state.apiToken
+          ? { Authorization: `Bearer ${state.apiToken}` }
+          : {}),
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: toolName, arguments: args },
+      }),
+    });
+
+    if (!res.ok) {
+      return {
+        content: `MCP gateway error: ${res.status} ${res.statusText}`,
+        isError: true,
+      };
+    }
+
+    const body = (await res.json()) as {
+      result?: {
+        content?: Array<{ type: string; text?: string }>;
+        isError?: boolean;
+      };
+      error?: { message?: string };
+    };
+
+    if (body.error) {
+      return {
+        content: `MCP error: ${body.error.message ?? "unknown"}`,
+        isError: true,
+      };
+    }
+
+    const textParts = (body.result?.content ?? [])
+      .filter((c) => c.type === "text" && c.text)
+      .map((c) => c.text as string);
+
+    return {
+      content: textParts.join("\n") || "(no output)",
+      isError: body.result?.isError ?? false,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// ── Tool creation ────────────────────────────────────────────────────
+
+/**
+ * Create an OpenClaw agent tool that proxies to a BitRouter MCP tool.
+ */
+function createMcpProxyTool(
+  toolInfo: ToolInfo,
+  state: BitrouterState,
+): AnyAgentTool {
+  const openClawName = toOpenClawToolName(toolInfo.id);
+
+  // Build a simple JSON schema parameters definition or fall back
+  // to a generic passthrough object.
+  const parameters = {
+    type: "object" as const,
+    properties: {
+      arguments: {
+        type: "object" as const,
+        description:
+          "Arguments to pass to the MCP tool. See tool description for available parameters.",
+        additionalProperties: true,
+      },
+    },
+  };
+
+  return {
+    name: openClawName,
+    label: `BitRouter MCP: ${toolInfo.name ?? toolInfo.id}`,
+    displaySummary: toolInfo.description ?? `MCP tool: ${toolInfo.id}`,
+    description:
+      `Proxy to BitRouter MCP tool "${toolInfo.id}" (provider: ${toolInfo.provider}).` +
+      (toolInfo.description ? `\n\n${toolInfo.description}` : "") +
+      (toolInfo.input_schema
+        ? `\n\nTool schema: ${JSON.stringify(toolInfo.input_schema)}`
+        : ""),
+    parameters,
+
+    execute: async (
+      _toolCallId: string,
+      params: { arguments?: Record<string, unknown> },
+    ): Promise<{
+      content: Array<{ type: string; text: string }>;
+      details: { isError: boolean };
+    }> => {
+      if (!state.healthy) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: "BitRouter is not healthy. Cannot execute MCP tool.",
+            },
+          ],
+          details: { isError: true },
+        };
+      }
+
+      const result = await callMcpTool(
+        state,
+        toolInfo.id,
+        params.arguments ?? {},
+      );
+
+      return {
+        content: [{ type: "text", text: result.content }],
+        details: { isError: result.isError },
+      };
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// ── Bridge controller ────────────────────────────────────────────────
+
+export interface McpToolsBridge {
+  /** Register tools currently known from state.knownTools. */
+  registerInitialTools(): void;
+  /**
+   * Sync tools: register new ones and report removed tools.
+   * Called during health check refresh cycles.
+   */
+  refresh(): void;
+  /** Set of currently registered OpenClaw tool names. */
+  readonly registeredToolNames: ReadonlySet<string>;
+}
+
+/**
+ * Create the MCP tools bridge that manages registering/unregistering
+ * MCP tools as optional OpenClaw agent tools.
+ */
+export function createMcpToolsBridge(
+  api: OpenClawPluginApi,
+  state: BitrouterState,
+): McpToolsBridge {
+  const registered = new Set<string>();
+
+  function registerToolsFromState(): void {
+    // Only register MCP tools (not skill entries).
+    const mcpTools = state.knownTools.filter((t) => t.provider !== "skill");
+
+    for (const tool of mcpTools) {
+      const name = toOpenClawToolName(tool.id);
+      if (registered.has(name)) continue;
+
+      try {
+        api.registerTool(createMcpProxyTool(tool, state), {
+          name,
+          optional: true,
+        });
+        registered.add(name);
+      } catch (err) {
+        api.logger.warn(`Failed to register MCP tool ${tool.id}: ${err}`);
+      }
+    }
+  }
+
+  function refresh(): void {
+    const mcpTools = state.knownTools.filter((t) => t.provider !== "skill");
+    const currentNames = new Set(mcpTools.map((t) => toOpenClawToolName(t.id)));
+
+    // Register new tools.
+    registerToolsFromState();
+
+    // Log removed tools (OpenClaw SDK doesn't support unregisterTool,
+    // so we just note the removal — the tool will fail gracefully if
+    // the backing MCP tool is gone).
+    for (const name of registered) {
+      if (!currentNames.has(name)) {
+        api.logger.info(`MCP tool removed upstream: ${name}`);
+        registered.delete(name);
+      }
+    }
+  }
+
+  return {
+    registerInitialTools: registerToolsFromState,
+    refresh,
+    get registeredToolNames() {
+      return registered;
+    },
+  };
+}

--- a/src/prompt-context.ts
+++ b/src/prompt-context.ts
@@ -16,22 +16,27 @@ import type {
   BitrouterState,
   OpenClawPluginApi,
 } from "./types.js";
+import { ALLOWED_COMMANDS_DESCRIPTION } from "./bitrouter-tool.js";
 
 // ── Static context (cacheable across turns) ──────────────────────────
 
-const STATIC_CONTEXT = `BitRouter LLM proxy is available. For route management, status, key generation, or admin operations use the /bitrouter skill or the CLI:
-  openclaw bitrouter status   — health, routes, agents, tools, daemon info
-  openclaw bitrouter agents   — list upstream A2A agents
-  openclaw bitrouter tools    — list available MCP tools and skills
-  openclaw bitrouter setup    — reconfigure provider/mode
-  openclaw bitrouter wallet   — wallet/onboarding state
+const STATIC_CONTEXT = `BitRouter LLM proxy is available. Use the \`bitrouter\` tool for route management, status checks, and administration.
+
+Available tool commands:
+  ${ALLOWED_COMMANDS_DESCRIPTION}
+
+Examples:
+  bitrouter tool → command: "status"
+  bitrouter tool → command: "models list"
+  bitrouter tool → command: "route add fast openai:gpt-4o-mini"
+  bitrouter tool → command: "route add research openai:o3 anthropic:claude-opus-4-20250514 --strategy load_balance"
+  bitrouter tool → command: "route rm fast"
 
 BitRouter also provides:
-  A2A Gateway — proxy upstream agents via /a2a/{agent_name} (message/send, message/stream, tasks/*)
   MCP Gateway — proxy upstream MCP servers via /mcp (tools/list, tools/call, resources/*, prompts/*)
   Skills Registry — manage agent skills via /v1/skills (CRUD) and discover via /v1/tools
 
-IMPORTANT — Model Selection: You have 33 models available at different cost/capability tiers. Before starting a task, actively choose the right model using the /model-select skill. Use \`bitrouter route add <name> openrouter:<model>\` to set task-appropriate routes. Do NOT default to auto/load-balance for every task — pick the cheapest tier that can handle the job well. Quick guide:
+IMPORTANT — Model Selection: Choose the right model for the task. Use \`bitrouter\` tool with "route add <name> openrouter:<model>" to set task-appropriate routes. Do NOT default to auto/load-balance for every task — pick the cheapest tier that can handle the job well. Quick guide:
   Frontier ($2-25/M out): claude-opus-4.6, gpt-5.4, gemini-3.1-pro — complex architecture, research
   Strong ($0.4-15/M out): claude-sonnet-4.6, qwen3-max-thinking, mistral-large-2512 — standard dev work
   Fast ($0.13-5/M out): claude-haiku-4.5, devstral-2512, gemini-2.5-flash, grok-4.1-fast, gpt-5-mini — simple tasks, high throughput
@@ -41,13 +46,11 @@ IMPORTANT — Model Selection: You have 33 models available at different cost/ca
 
 function buildDynamicContext(
   config: BitrouterPluginConfig,
-  state: BitrouterState
+  state: BitrouterState,
 ): string {
   const mode = config.mode ?? "unconfigured";
   const upstream =
-    mode === "byok"
-      ? `/${config.byok?.upstreamProvider ?? "unknown"}`
-      : "";
+    mode === "byok" ? `/${config.byok?.upstreamProvider ?? "unknown"}` : "";
 
   const healthTag = state.healthy ? ", healthy" : "";
 
@@ -65,9 +68,10 @@ function buildDynamicContext(
   if (state.knownAgents.length > 0) {
     const agentSummary = state.knownAgents
       .map((a) => {
-        const skills = a.skills.length > 0
-          ? ` (${a.skills.map((s) => s.name).join(", ")})`
-          : "";
+        const skills =
+          a.skills.length > 0
+            ? ` (${a.skills.map((s) => s.name).join(", ")})`
+            : "";
         return `${a.id}${skills}`;
       })
       .join("; ");
@@ -103,7 +107,7 @@ function buildDynamicContext(
 export function registerPromptContext(
   api: OpenClawPluginApi,
   config: BitrouterPluginConfig,
-  state: BitrouterState
+  state: BitrouterState,
 ): void {
   api.on("before_prompt_build", (_event, _ctx) => {
     return {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -37,6 +37,7 @@ import { buildCatalogHandler } from "./discovery.js";
 import { PROVIDER_API_BASES, toEnvVarKey } from "./config.js";
 import { ensureAuthViaCli } from "./bitrouter-cli.js";
 import { detectProviders } from "./discovery.js";
+import { fetchMetrics, formatUsageText } from "./usage.js";
 
 // ── Non-interactive auth ──────────────────────────────────────────────
 
@@ -51,7 +52,7 @@ import { detectProviders } from "./discovery.js";
  */
 async function byokNonInteractive(
   ctx: ProviderAuthMethodNonInteractiveContext,
-  api: OpenClawPluginApi
+  api: OpenClawPluginApi,
 ): Promise<Record<string, unknown> | null> {
   // Try to resolve a BitRouter-specific API key first (for pre-configured setups).
   const resolved = await ctx.resolveApiKey({
@@ -94,7 +95,7 @@ async function byokNonInteractive(
   const detected = detectProviders(api);
   if (detected.length === 0) {
     api.logger.info(
-      "BitRouter non-interactive auth: no API keys found in environment"
+      "BitRouter non-interactive auth: no API keys found in environment",
     );
     return null;
   }
@@ -111,14 +112,13 @@ async function byokNonInteractive(
 
   api.logger.info(
     `BitRouter non-interactive auth: auto-configuring with ${primary.name} ` +
-      `(${primary.envVarKey})`
+      `(${primary.envVarKey})`,
   );
 
   // Generate JWT for authenticating with local BitRouter.
-  const homeDir =
-    ctx.workspaceDir
-      ? `${ctx.workspaceDir}/bitrouter`
-      : `${process.env.HOME}/.openclaw/bitrouter`;
+  const homeDir = ctx.workspaceDir
+    ? `${ctx.workspaceDir}/bitrouter`
+    : `${process.env.HOME}/.openclaw/bitrouter`;
 
   const stateDir = ctx.workspaceDir
     ? `${ctx.workspaceDir}/plugins/bitrouter`
@@ -130,7 +130,7 @@ async function byokNonInteractive(
   // If multiple providers detected, use auto mode instead of byok.
   if (detected.length > 1) {
     api.logger.info(
-      `BitRouter non-interactive auth: ${detected.length} providers detected, using auto mode`
+      `BitRouter non-interactive auth: ${detected.length} providers detected, using auto mode`,
     );
     return {
       plugins: {
@@ -197,7 +197,7 @@ async function byokNonInteractive(
 export function registerBitrouterProvider(
   api: OpenClawPluginApi,
   _config: BitrouterPluginConfig,
-  state: BitrouterState
+  state: BitrouterState,
 ): void {
   // Collect env var names for all well-known providers.
   const envVars = [
@@ -224,7 +224,10 @@ export function registerBitrouterProvider(
         // Detects API keys from environment variables and auto-configures.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         runNonInteractive: (ctx: any) =>
-          byokNonInteractive(ctx as ProviderAuthMethodNonInteractiveContext, api),
+          byokNonInteractive(
+            ctx as ProviderAuthMethodNonInteractiveContext,
+            api,
+          ),
       },
       {
         id: "cloud",
@@ -265,7 +268,7 @@ export function registerBitrouterProvider(
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: knownModel?.context_window ?? 128_000,
         maxTokens: knownModel?.max_tokens ?? 16_384,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any;
     },
 
@@ -285,6 +288,55 @@ export function registerBitrouterProvider(
         return (cred as { key: string }).key;
       }
       return state.apiToken ?? "";
+    },
+
+    // ── Usage & spend tracking ─────────────────────────────────────
+
+    // Resolve auth for usage endpoints — use the local JWT token.
+    resolveUsageAuth: async () => {
+      const token = state.apiToken;
+      if (!token) return null;
+      return { token };
+    },
+
+    // Fetch usage/spend snapshot from BitRouter's /v1/metrics endpoint.
+    fetchUsageSnapshot: async () => {
+      const metrics = await fetchMetrics(state);
+      if (!metrics) return null;
+
+      const text = formatUsageText(metrics);
+      const totalRequests = Object.values(metrics.routes).reduce(
+        (sum, r) => sum + r.total_requests,
+        0,
+      );
+
+      // Return a provider-compatible snapshot shape.
+      // Since "bitrouter" isn't in the core UsageProviderId union,
+      // we return the data through the generic provider surface.
+      return {
+        provider: "bitrouter",
+        displayName: "BitRouter",
+        windows: [
+          {
+            label: `${totalRequests} requests across ${Object.keys(metrics.routes).length} routes`,
+            usedPercent: 0,
+          },
+        ],
+        plan: text,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
+    },
+
+    // ── Auth guidance ──────────────────────────────────────────────
+
+    // Custom missing-auth message for BitRouter.
+    buildMissingAuthMessage: () => {
+      return (
+        "BitRouter is not authenticated. Run one of:\n" +
+        "  openclaw bitrouter setup        — interactive onboarding wizard\n" +
+        "  openclaw models auth login --provider bitrouter  — configure auth\n" +
+        "  export BITROUTER_API_KEY=...    — set API key directly"
+      );
     },
   });
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -2,22 +2,16 @@
  * Provider registration — registers "bitrouter" as an LLM provider in
  * OpenClaw, pointing to the local BitRouter instance.
  *
- * Three auth methods are offered:
+ * Auth method:
  *
- *   byok  — Bring Your Own Key: interactive wizard that collects an
- *            upstream provider (OpenRouter, OpenAI, Anthropic, or custom)
- *            and an API key. Persists mode + byok config via configPatch.
- *
- *   cloud — BitRouter Cloud stub (coming soon). Shows a "coming soon"
- *            message and exits without making changes.
- *
- *   byok (non-interactive) — Headless/CI flow that detects API keys
- *            from environment variables and auto-configures BitRouter.
+ *   byok  — Delegates to `bitrouter auth login` via the native CLI
+ *            (system binary on PATH or plugin's bundled copy). The CLI
+ *            handles provider selection, API key entry, and OAuth flows.
+ *            A non-interactive path detects API keys from env vars for
+ *            headless/CI environments.
  *
  * The wizard is triggered by:
  *   openclaw models auth login --provider bitrouter
- *   openclaw models auth login --provider bitrouter --method byok
- *   openclaw models auth login --provider bitrouter --method cloud
  *
  * Provider features:
  *   - discovery: publishes BitRouter's routing table into the model catalog
@@ -32,7 +26,7 @@ import type {
   ProviderAuthMethodNonInteractiveContext,
 } from "./types.js";
 import { DEFAULTS } from "./types.js";
-import { byokWizard, cloudSetupHint } from "./setup.js";
+import { byokWizard } from "./setup.js";
 import { buildCatalogHandler } from "./discovery.js";
 import { PROVIDER_API_BASES, toEnvVarKey } from "./config.js";
 import { ensureAuthViaCli } from "./bitrouter-cli.js";
@@ -215,8 +209,8 @@ export function registerBitrouterProvider(
     auth: [
       {
         id: "byok",
-        label: "BYOK — bring your own API key",
-        hint: "Route through OpenRouter, OpenAI, Anthropic, or any compatible API",
+        label: "Set up BitRouter provider authentication",
+        hint: "Runs `bitrouter auth login` to configure providers (API keys, OAuth, etc.)",
         kind: "api_key" as const,
         run: byokWizard,
 
@@ -228,13 +222,6 @@ export function registerBitrouterProvider(
             ctx as ProviderAuthMethodNonInteractiveContext,
             api,
           ),
-      },
-      {
-        id: "cloud",
-        label: "BitRouter Cloud (wallet setup)",
-        hint: "Set up Swig wallet for x402 payments via interactive CLI",
-        kind: "oauth" as const,
-        run: cloudSetupHint,
       },
     ],
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -34,7 +34,12 @@ import {
 } from "./config.js";
 import { ensureAuthViaCli } from "./bitrouter-cli.js";
 import { startHealthCheck, stopHealthCheck, waitForReady } from "./health.js";
-import { refreshRoutes, refreshAgents, refreshTools, refreshSkills } from "./routing.js";
+import {
+  refreshRoutes,
+  refreshAgents,
+  refreshTools,
+  refreshSkills,
+} from "./routing.js";
 import { resolveBinaryPath } from "./binary.js";
 import { buildAutoProviderConfig, type DetectedProvider } from "./discovery.js";
 import { loadOnboardingState } from "./onboarding.js";
@@ -49,6 +54,7 @@ export function registerBitrouterService(
   config: BitrouterPluginConfig,
   state: BitrouterState,
   stateDirRef: { value: string },
+  onRefresh?: () => void,
 ): void {
   api.registerService({
     id: "bitrouter",
@@ -174,7 +180,7 @@ export function registerBitrouterService(
       }
 
       // 5. Start periodic health checks.
-      startHealthCheck(api, config, state);
+      startHealthCheck(api, config, state, onRefresh);
     },
 
     stop: async (_ctx: OpenClawPluginServiceContext) => {
@@ -373,9 +379,7 @@ function resolveProviderApiBase(
  * them here. The provider:modelId pairs are passed-through as-is
  * (e.g. OpenRouter accepts "auto" as a valid model identifier).
  */
-function buildDefaultModelRoutes(
-  upstreamProvider: string,
-): Record<
+function buildDefaultModelRoutes(upstreamProvider: string): Record<
   string,
   {
     strategy: "priority";

--- a/src/service.ts
+++ b/src/service.ts
@@ -94,15 +94,17 @@ export function registerBitrouterService(
       // Load onboarding state from onboarding.json (written by Rust CLI).
       state.onboardingState = loadOnboardingState(state.homeDir);
 
-      // Ensure a bitrouter account exists and mint JWTs for authenticating
-      // with the local BitRouter instance (API + admin scopes).
+      // Ensure an OWS wallet exists and mint a JWT for authenticating
+      // with the local BitRouter instance.
       try {
-        const tokens = await ensureAuthViaCli(ctx.stateDir, state.homeDir);
-        state.apiToken = tokens.apiToken;
-        state.adminToken = tokens.adminToken;
-        api.logger.info("Auth tokens ready (via bitrouter CLI)");
+        const { apiToken } = await ensureAuthViaCli(
+          ctx.stateDir,
+          state.homeDir,
+        );
+        state.apiToken = apiToken;
+        api.logger.info("Auth token ready (via bitrouter CLI)");
       } catch (err) {
-        api.logger.warn(`Failed to generate auth tokens: ${err}`);
+        api.logger.warn(`Failed to generate auth token: ${err}`);
       }
 
       // 2. Find the binary (downloads from GitHub releases if not cached).

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,25 +2,19 @@
  * BitRouter first-run setup wizard.
  *
  * Runs inside the `openclaw models auth login --provider bitrouter` flow.
- * Two auth methods are registered on the provider:
  *
- *   byok  — Bring Your Own Key: interactive wizard that collects an
- *            upstream provider (OpenRouter, OpenAI, Anthropic, or custom)
- *            and an API key. Persists mode + byok config via configPatch.
- *
- *   cloud — BitRouter Cloud (stub; OAuth coming in next version). Shows a
- *            "coming soon" message and exits without making changes.
+ * Always delegates to the `bitrouter auth login` CLI command — either
+ * the system-installed binary on PATH or the plugin's bundled copy.
+ * The native CLI handles wallet creation, provider auth (API key + OAuth),
+ * and config generation with its own interactive prompts, so we avoid
+ * duplicating the provider-picker UI here.
  *
  * On success, returns a ProviderAuthResult whose `configPatch` writes
- * `mode` and `byok` into `plugins.entries.bitrouter.config` in
- * openclaw.json — no filesystem
- * hacks required.
- *
- * The API key is also written to the BitRouter home dir's .env file so
- * the service can inject it into bitrouter.yaml on startup.
+ * `mode` into `plugins.entries.bitrouter.config` in openclaw.json, and
+ * a JWT credential for authenticating with the local BitRouter instance.
  */
 
-import * as fs from "node:fs";
+import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import * as os from "node:os";
 
@@ -30,202 +24,65 @@ import type {
   SetupMode,
 } from "./types.js";
 import { DEFAULTS } from "./types.js";
-import { PROVIDER_API_BASES, toEnvVarKey, parseEnvFile, serializeEnvFile } from "./config.js";
 import { ensureAuthViaCli } from "./bitrouter-cli.js";
-
-// ── Well-known upstream providers ────────────────────────────────────
-
-type UpstreamProviderId = "openrouter" | "openai" | "anthropic" | "other";
-
-interface UpstreamProviderMeta {
-  value: UpstreamProviderId;
-  label: string;
-  hint: string;
-  apiBase?: string;
-  keyPlaceholder: string;
-  docsUrl?: string;
-}
-
-const UPSTREAM_PROVIDERS: UpstreamProviderMeta[] = [
-  {
-    value: "openrouter",
-    label: "OpenRouter",
-    hint: "Access 100+ models via a single key — recommended",
-    apiBase: PROVIDER_API_BASES.openrouter,
-    keyPlaceholder: "sk-or-...",
-    docsUrl: "https://openrouter.ai/keys",
-  },
-  {
-    value: "openai",
-    label: "OpenAI",
-    hint: "GPT-4o, o1, and other OpenAI models",
-    apiBase: PROVIDER_API_BASES.openai,
-    keyPlaceholder: "sk-...",
-    docsUrl: "https://platform.openai.com/api-keys",
-  },
-  {
-    value: "anthropic",
-    label: "Anthropic",
-    hint: "Claude 3.5, Claude 3 Opus, and others",
-    apiBase: PROVIDER_API_BASES.anthropic,
-    keyPlaceholder: "sk-ant-...",
-    docsUrl: "https://console.anthropic.com/settings/keys",
-  },
-  {
-    value: "other",
-    label: "Other / self-hosted",
-    hint: "Any OpenAI-compatible API (Ollama, LM Studio, etc.)",
-    keyPlaceholder: "",
-  },
-];
+import { resolveBinaryPath } from "./binary.js";
 
 // ── BYOK wizard ──────────────────────────────────────────────────────
 
 /**
- * Run the BYOK setup wizard.
+ * Run the auth setup wizard.
  *
  * Registered as the "byok" ProviderAuthMethod on the "bitrouter" provider.
- * Called by: `openclaw models auth login --provider bitrouter --method byok`
- * or: `openclaw models auth login --provider bitrouter` (first choice).
+ * Called by: `openclaw models auth login --provider bitrouter`
+ *
+ * Always delegates to `bitrouter auth login` — the native CLI handles
+ * wallet creation, provider selection, API key entry, and OAuth device
+ * flows with its own interactive prompts. We resolve the binary from
+ * PATH first, then fall back to the plugin's bundled/downloaded copy.
+ *
+ * After `bitrouter auth login` completes, mints a JWT for OpenClaw's
+ * credential store.
  */
 export async function byokWizard(
-  ctx: ProviderAuthContext
+  ctx: ProviderAuthContext,
 ): Promise<ProviderAuthResult> {
-  const { prompter } = ctx;
+  const stateDir =
+    ctx.workspaceDir ?? `${os.homedir()}/.openclaw/plugins/bitrouter`;
+  const homeDir = resolveSetupHomeDir(ctx);
 
-  await prompter.intro("BitRouter — BYOK Setup");
-  await prompter.note(
-    "BitRouter proxies your LLM requests locally, adding failover,\n" +
-      "load balancing, and metrics. Your API key is stored securely\n" +
-      "in OpenClaw's credential store.",
-    "Welcome"
+  const binaryPath = await resolveBinaryPath(stateDir);
+
+  const result = spawnSync(
+    binaryPath,
+    ["--home-dir", homeDir, "auth", "login"],
+    { stdio: "inherit" },
   );
 
-  // ── Step 1: Choose upstream provider ────────────────────────────
-
-  const providerChoice = await prompter.select<UpstreamProviderId>({
-    message: "Which LLM provider do you want BitRouter to route through?",
-    options: UPSTREAM_PROVIDERS.map((p) => ({
-      value: p.value,
-      label: p.label,
-      hint: p.hint,
-    })),
-    initialValue: "openrouter",
-  });
-
-  const providerMeta = UPSTREAM_PROVIDERS.find(
-    (p) => p.value === providerChoice
-  )!;
-
-  // ── Step 2: API key ──────────────────────────────────────────────
-
-  let apiBase: string | undefined;
-
-  if (providerChoice === "other") {
-    apiBase = await prompter.text({
-      message: "API base URL (must be OpenAI-compatible):",
-      placeholder: "http://localhost:11434/v1",
-      validate: (v) => {
-        if (!v.trim()) return "Base URL is required for custom providers.";
-        try {
-          new URL(v.trim());
-        } catch {
-          return "Enter a valid URL (e.g. http://localhost:11434/v1)";
-        }
-        return undefined;
-      },
-    });
-  } else {
-    apiBase = providerMeta.apiBase;
+  if (result.status !== 0) {
+    throw new Error(
+      `bitrouter auth login exited with code ${result.status}` +
+        (result.error ? `: ${result.error.message}` : ""),
+    );
   }
 
-  const keyHint =
-    providerMeta.docsUrl
-      ? `Get your key at ${providerMeta.docsUrl}`
-      : "Paste your API key below.";
-
-  await prompter.note(keyHint);
-
-  const apiKey = await prompter.text({
-    message: `${providerMeta.label} API key:`,
-    placeholder:
-      providerChoice !== "other" ? providerMeta.keyPlaceholder : "sk-...",
-    validate: (v) => {
-      if (!v.trim()) return "API key cannot be empty.";
-      if (v.trim().length < 8) return "That doesn't look like a valid API key.";
-      return undefined;
-    },
-  });
-
-  // ── Step 3: Confirm ──────────────────────────────────────────────
-
-  const confirmed = await prompter.confirm({
-    message: `Route all agent requests through BitRouter → ${providerMeta.label}?`,
-    initialValue: true,
-  });
-
-  if (!confirmed) {
-    throw new Error("Setup cancelled.");
-  }
-
-  // ── Done ─────────────────────────────────────────────────────────
-
-  // Write the API key to the BitRouter home dir's .env file so the service
-  // can pick it up at startup without re-prompting.
-  const homeDir = resolveSetupHomeDir(ctx);
-  writeKeyToEnv(homeDir, providerChoice, apiKey.trim());
-
-  // Ensure a bitrouter account exists and mint a JWT for authenticating
-  // with the local BitRouter instance. Delegates to the bitrouter CLI.
-  const stateDir = ctx.workspaceDir ?? `${os.homedir()}/.openclaw/plugins/bitrouter`;
+  // Mint a JWT so OpenClaw can authenticate with the local instance.
   const { apiToken: jwt } = await ensureAuthViaCli(stateDir, homeDir);
 
-  await prompter.outro(
-    "BitRouter configured! Next steps:\n" +
-      "  1. Restart the gateway: openclaw gateway restart\n" +
-      "  2. Route all agents through BitRouter: openclaw bitrouter switch-all"
-  );
+  // Start the BitRouter daemon so it's running immediately after setup.
+  // `bitrouter start` is idempotent — if the daemon is already running
+  // it will report that and exit cleanly.
+  console.log("\nStarting BitRouter daemon...\n");
+  const startResult = spawnSync(binaryPath, ["--home-dir", homeDir, "start"], {
+    stdio: "inherit",
+  });
+  if (startResult.status !== 0) {
+    console.warn(
+      `\nWarning: bitrouter start exited with code ${startResult.status}. ` +
+        "You can start it manually with: bitrouter start\n",
+    );
+  }
 
-  // Build the config patch. This gets merged into openclaw.json by OpenClaw.
-  //
-  // Two things we patch:
-  //
-  // 1. plugins.entries.bitrouter.config — stores mode/byok settings so the
-  //    plugin knows it's configured on next gateway start.
-  //
-  // 2. models.providers.bitrouter — registers "bitrouter" as a provider with
-  //    baseUrl pointing to the local BitRouter instance. Use
-  //    `openclaw bitrouter switch-all` to route all agent models through
-  //    BitRouter by rewriting their model configs.
   const bitrouterApiBase = `http://${DEFAULTS.host}:${DEFAULTS.port}/v1`;
-
-  const configPatch = {
-    plugins: {
-      entries: {
-        bitrouter: {
-          config: {
-            mode: "byok" satisfies SetupMode,
-            byok: {
-              upstreamProvider: providerChoice,
-              ...(apiBase ? { apiBase } : {}),
-            },
-          },
-        },
-      },
-    },
-    // Register "bitrouter" as a provider pointing to the local instance.
-    // Use `openclaw bitrouter switch-all` to route all agent models
-    // through BitRouter.
-    models: {
-      mode: "merge" as const,
-      providers: {
-        bitrouter: {
-          baseUrl: bitrouterApiBase,
-          models: [],
-        },
-      },
-    },
-  };
 
   return {
     profiles: [
@@ -238,12 +95,29 @@ export async function byokWizard(
         },
       },
     ],
-    configPatch,
+    configPatch: {
+      plugins: {
+        entries: {
+          bitrouter: {
+            config: {
+              mode: "byok" satisfies SetupMode,
+            },
+          },
+        },
+      },
+      models: {
+        mode: "merge" as const,
+        providers: {
+          bitrouter: {
+            baseUrl: bitrouterApiBase,
+            models: [],
+          },
+        },
+      },
+    },
     notes: [
-      `Upstream provider: ${providerMeta.label}`,
-      `BitRouter will intercept all model requests via providerOverride (127.0.0.1:8787/v1).`,
+      "BitRouter configured and daemon started.",
       "Restart the gateway to activate: openclaw gateway restart",
-      "To change settings, run: openclaw models auth login --provider bitrouter",
     ],
   };
 }
@@ -263,69 +137,4 @@ function resolveSetupHomeDir(ctx: ProviderAuthContext): string {
     return path.join(ctx.workspaceDir, "bitrouter");
   }
   return path.join(os.homedir(), ".openclaw", "bitrouter");
-}
-
-/**
- * Write the API key to the BitRouter home dir's .env file.
- * The key name follows the pattern PROVIDER_API_KEY.
- */
-function writeKeyToEnv(
-  homeDir: string,
-  provider: string,
-  apiKey: string
-): void {
-  try {
-    fs.mkdirSync(homeDir, { recursive: true });
-    const envPath = path.join(homeDir, ".env");
-    const envKey = toEnvVarKey(provider);
-
-    // Read existing .env entries (if any) and merge.
-    let entries = new Map<string, string>();
-    try {
-      entries = parseEnvFile(fs.readFileSync(envPath, "utf-8"));
-    } catch {
-      // File doesn't exist yet — start fresh.
-    }
-
-    entries.set(envKey, apiKey);
-    fs.writeFileSync(envPath, serializeEnvFile(entries), "utf-8");
-  } catch (err) {
-    // Non-fatal — the service will fall back to env vars.
-    console.warn(`[bitrouter] Warning: could not write .env file: ${err}`);
-  }
-}
-
-// ── Cloud setup hint ─────────────────────────────────────────────────
-
-/**
- * Direct the user to the interactive CLI for Swig wallet onboarding.
- *
- * The Rust binary's `bitrouter init` uses `dialoguer` for interactive
- * prompts, which requires raw terminal access. The OpenClaw prompter
- * API cannot proxy this, so we point the user to the CLI command.
- */
-export async function cloudSetupHint(
-  ctx: ProviderAuthContext
-): Promise<ProviderAuthResult> {
-  const { prompter } = ctx;
-
-  await prompter.intro("BitRouter Cloud — Swig Wallet Setup");
-  await prompter.note(
-    "Cloud mode requires interactive wallet onboarding via the CLI.\n\n" +
-      "Run the following command in your terminal:\n\n" +
-      "  openclaw bitrouter setup\n\n" +
-      "This will launch the BitRouter onboarding wizard which sets up\n" +
-      "a Swig wallet for x402 cloud payments. Once complete, restart\n" +
-      "the gateway to activate cloud mode.",
-    "Setup Required"
-  );
-  await prompter.outro("No changes made — run `openclaw bitrouter setup` to continue.");
-
-  return {
-    profiles: [],
-    notes: [
-      "Cloud mode requires interactive CLI setup.",
-      "Run: openclaw bitrouter setup",
-    ],
-  };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,7 +137,9 @@ export interface McpServerConfigEntry {
   command: string;
   args?: string[];
   toolFilter?: { allow?: string[]; deny?: string[] };
-  paramRestrictions?: { rules?: Array<{ tool: string; forbiddenParams?: string[] }> };
+  paramRestrictions?: {
+    rules?: Array<{ tool: string; forbiddenParams?: string[] }>;
+  };
 }
 
 /** Skill configuration entry. */
@@ -156,7 +158,9 @@ export interface PricingConfig {
 }
 
 /** Agent model config — mirrors the SDK's model field shape. */
-export type AgentModelConfig = string | { primary?: string; fallbacks?: string[] };
+export type AgentModelConfig =
+  | string
+  | { primary?: string; fallbacks?: string[] };
 
 /** A single provider entry in the plugin config (camelCase, TS-side). */
 export interface ProviderEntry {
@@ -314,7 +318,11 @@ export interface MetricsResponse {
 export interface GuardrailPluginConfig {
   enabled?: boolean;
   disabledPatterns?: string[];
-  customPatterns?: Array<{ name: string; regex: string; direction?: "upgoing" | "downgoing" | "both" }>;
+  customPatterns?: Array<{
+    name: string;
+    regex: string;
+    direction?: "upgoing" | "downgoing" | "both";
+  }>;
   upgoing?: Record<string, "warn" | "redact" | "block">;
   downgoing?: Record<string, "warn" | "redact" | "block">;
 }
@@ -382,8 +390,6 @@ export interface BitrouterState {
   metrics: MetricsResponse | null;
   /** JWT token for API-scope requests to the local BitRouter instance. */
   apiToken: string | null;
-  /** JWT token for admin-scope requests (24h expiry, auto-refreshed). */
-  adminToken: string | null;
   /** Providers detected via env var sniffing in auto mode. */
   autoDetectedProviders?: import("./discovery.js").DetectedProvider[];
   /** Onboarding state loaded from onboarding.json (null if not present). */

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,113 @@
+/**
+ * Usage & spend tracking — hooks into BitRouter's /v1/metrics endpoint
+ * to provide usage data for the provider's usage surface.
+ *
+ * Since BitRouter is a proxy/router, it aggregates metrics across all
+ * upstream providers. The resolveUsageAuth hook returns the local JWT
+ * token, and fetchUsageSnapshot fetches and normalizes BitRouter's
+ * per-route metrics into a usage snapshot.
+ */
+
+import type { BitrouterState, MetricsResponse } from "./types.js";
+
+// ── Metrics fetching ─────────────────────────────────────────────────
+
+/**
+ * Fetch metrics from BitRouter's /v1/metrics endpoint.
+ * Updates state.metrics on success. Returns null on failure.
+ */
+export async function fetchMetrics(
+  state: BitrouterState,
+): Promise<MetricsResponse | null> {
+  if (!state.healthy) return null;
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    const res = await fetch(`${state.baseUrl}/v1/metrics`, {
+      signal: controller.signal,
+      headers: state.apiToken
+        ? { Authorization: `Bearer ${state.apiToken}` }
+        : undefined,
+    });
+    clearTimeout(timeout);
+
+    if (!res.ok) return null;
+
+    const body = (await res.json()) as MetricsResponse;
+    state.metrics = body;
+    return body;
+  } catch {
+    return null;
+  }
+}
+
+// ── Usage summary ────────────────────────────────────────────────────
+
+export interface UsageSummaryLine {
+  route: string;
+  requests: number;
+  errors: number;
+  p50Ms: number | null;
+  p99Ms: number | null;
+  avgInputTokens: number | null;
+  avgOutputTokens: number | null;
+  lastUsed: string | null;
+}
+
+/**
+ * Convert BitRouter metrics into a human-readable usage summary.
+ * Used by the provider's fetchUsageSnapshot hook and the status CLI.
+ */
+export function summarizeMetrics(metrics: MetricsResponse): {
+  uptime: number;
+  routes: UsageSummaryLine[];
+} {
+  const routes: UsageSummaryLine[] = [];
+
+  for (const [routeName, routeMetrics] of Object.entries(metrics.routes)) {
+    routes.push({
+      route: routeName,
+      requests: routeMetrics.total_requests,
+      errors: routeMetrics.total_errors,
+      p50Ms: routeMetrics.latency_p50_ms ?? null,
+      p99Ms: routeMetrics.latency_p99_ms ?? null,
+      avgInputTokens: routeMetrics.avg_input_tokens ?? null,
+      avgOutputTokens: routeMetrics.avg_output_tokens ?? null,
+      lastUsed: routeMetrics.last_used ?? null,
+    });
+  }
+
+  return { uptime: metrics.uptime_seconds, routes };
+}
+
+/**
+ * Format usage metrics as a text block for display.
+ */
+export function formatUsageText(metrics: MetricsResponse): string {
+  const summary = summarizeMetrics(metrics);
+  const lines: string[] = [
+    `BitRouter Uptime: ${Math.floor(summary.uptime / 60)}m ${Math.floor(summary.uptime % 60)}s`,
+    "",
+  ];
+
+  if (summary.routes.length === 0) {
+    lines.push("No route metrics recorded yet.");
+    return lines.join("\n");
+  }
+
+  lines.push("Route Metrics:");
+  for (const r of summary.routes) {
+    const parts = [`  ${r.route}: ${r.requests} req, ${r.errors} err`];
+    if (r.p50Ms !== null) parts.push(`p50=${r.p50Ms}ms`);
+    if (r.p99Ms !== null) parts.push(`p99=${r.p99Ms}ms`);
+    if (r.avgInputTokens !== null) parts.push(`avg_in=${r.avgInputTokens}tok`);
+    if (r.avgOutputTokens !== null)
+      parts.push(`avg_out=${r.avgOutputTokens}tok`);
+    if (r.lastUsed) parts.push(`last=${r.lastUsed}`);
+    lines.push(parts.join(", "));
+  }
+
+  return lines.join("\n");
+}

--- a/tests/bitrouter-install-tool.test.ts
+++ b/tests/bitrouter-install-tool.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../src/binary.js", () => ({
+  findSystemBinary: vi.fn(() => null),
+}));
+
+import { spawn } from "node:child_process";
+import { createBitrouterInstallTool } from "../src/bitrouter-install-tool.js";
+import { findSystemBinary } from "../src/binary.js";
+
+function mockSpawn(opts: {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+}) {
+  (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    setImmediate(() => {
+      if (opts.stdout) child.stdout.emit("data", Buffer.from(opts.stdout));
+      if (opts.stderr) child.stderr.emit("data", Buffer.from(opts.stderr));
+      child.emit("close", opts.exitCode ?? 0);
+    });
+    return child;
+  });
+}
+
+describe("bitrouter_install tool", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a tool with the expected metadata", () => {
+    const tool = createBitrouterInstallTool();
+    expect(tool.name).toBe("bitrouter_install");
+    expect(tool.label).toBe("Install BitRouter");
+    expect(tool.description).toContain("install");
+    expect(tool.description).toContain("https://bitrouter.ai/install.sh");
+  });
+
+  it("reports a fresh install when binary appears after install", async () => {
+    const findMock = findSystemBinary as unknown as ReturnType<typeof vi.fn>;
+    findMock
+      .mockReturnValueOnce(null) // before
+      .mockReturnValueOnce("/usr/local/bin/bitrouter"); // after
+    mockSpawn({ stdout: "downloading...\ninstalled\n", exitCode: 0 });
+
+    const tool = createBitrouterInstallTool();
+    const result = await tool.execute("call-install-1", {});
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(result.details.exitCode).toBe(0);
+    expect(result.content[0].text).toContain("BitRouter installed");
+    expect(result.content[0].text).toContain("/usr/local/bin/bitrouter");
+  });
+
+  it("reports an update when binary already existed", async () => {
+    const findMock = findSystemBinary as unknown as ReturnType<typeof vi.fn>;
+    findMock
+      .mockReturnValueOnce("/usr/local/bin/bitrouter")
+      .mockReturnValueOnce("/usr/local/bin/bitrouter");
+    mockSpawn({ stdout: "updated\n", exitCode: 0 });
+
+    const tool = createBitrouterInstallTool();
+    const result = await tool.execute("call-install-2", {});
+
+    expect(result.details.exitCode).toBe(0);
+    expect(result.content[0].text).toContain("BitRouter updated");
+  });
+
+  it("reports installer failure", async () => {
+    const findMock = findSystemBinary as unknown as ReturnType<typeof vi.fn>;
+    findMock.mockReturnValue(null);
+    mockSpawn({ stderr: "network error\n", exitCode: 1 });
+
+    const tool = createBitrouterInstallTool();
+    const result = await tool.execute("call-install-3", {});
+
+    expect(result.details.exitCode).toBe(1);
+    expect(result.content[0].text).toContain("Installer failed");
+    expect(result.content[0].text).toContain("network error");
+  });
+
+  it("warns when installer reports success but binary still missing", async () => {
+    const findMock = findSystemBinary as unknown as ReturnType<typeof vi.fn>;
+    findMock.mockReturnValue(null);
+    mockSpawn({ stdout: "done\n", exitCode: 0 });
+
+    const tool = createBitrouterInstallTool();
+    const result = await tool.execute("call-install-4", {});
+
+    expect(result.details.exitCode).toBe(0);
+    expect(result.content[0].text).toContain("still not on $PATH");
+  });
+
+  it("respects abort signal", async () => {
+    const tool = createBitrouterInstallTool();
+    const controller = new AbortController();
+    controller.abort();
+    const result = await tool.execute("call-install-5", {}, controller.signal);
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(result.details.exitCode).toBe(130);
+    expect(result.content[0].text).toBe("Aborted.");
+  });
+});

--- a/tests/bitrouter-tool.test.ts
+++ b/tests/bitrouter-tool.test.ts
@@ -43,7 +43,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };

--- a/tests/bitrouter-tool.test.ts
+++ b/tests/bitrouter-tool.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Tests for the unified `bitrouter` agent tool.
+ *
+ * Tests focus on:
+ * - Command allowlist validation
+ * - Tokenization of command strings
+ * - Rejection of blocked commands
+ * - Successful dispatch (mocked binary execution)
+ */
+
+// Mock child_process before importing.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+// Mock binary resolution.
+vi.mock("../src/binary.js", () => ({
+  resolveBinaryPath: vi.fn(() => Promise.resolve("/usr/local/bin/bitrouter")),
+}));
+
+import { execFile } from "node:child_process";
+import {
+  createBitrouterTool,
+  ALLOWED_COMMANDS_DESCRIPTION,
+} from "../src/bitrouter-tool.js";
+import type { BitrouterState } from "../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
+  return {
+    process: null,
+    healthy: true,
+    baseUrl: "http://127.0.0.1:8787",
+    knownRoutes: [],
+    knownModels: [],
+    knownAgents: [],
+    knownTools: [],
+    knownSkills: [],
+    healthCheckTimer: null,
+    homeDir: "/tmp/bitrouter-test",
+    metrics: null,
+    apiToken: null,
+    adminToken: null,
+    onboardingState: null,
+    ...overrides,
+  };
+}
+
+function mockExecFileSuccess(stdout: string, stderr = "") {
+  (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      cb(null, stdout, stderr);
+    },
+  );
+}
+
+function mockExecFileFailure(stderr: string, code = 1) {
+  (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    (_cmd: string, _args: string[], _opts: unknown, cb: Function) => {
+      const err = new Error(`exit code ${code}`) as Error & { code: number };
+      err.code = code;
+      cb(err, "", stderr);
+    },
+  );
+}
+
+describe("bitrouter tool", () => {
+  const state = createMockState();
+  const stateDirRef = { value: "/tmp/plugins/bitrouter" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a tool with correct name and description", () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    expect(tool.name).toBe("bitrouter");
+    expect(tool.description).toContain("Available commands");
+    expect(tool.label).toBe("BitRouter CLI");
+  });
+
+  it("exports ALLOWED_COMMANDS_DESCRIPTION", () => {
+    expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter status");
+    expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter models list");
+    expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter route add");
+    expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter route rm");
+  });
+
+  // ── Allowed commands ─────────────────────────────────────────────
+
+  it("executes 'status' command", async () => {
+    mockExecFileSuccess("BitRouter v0.12.0 running");
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-1", { command: "status" });
+
+    expect(result.content[0]).toEqual({
+      type: "text",
+      text: "BitRouter v0.12.0 running",
+    });
+    expect(result.details.exitCode).toBe(0);
+
+    // Verify binary was called with --home-dir and the command.
+    const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[1]).toEqual(["--home-dir", "/tmp/bitrouter-test", "status"]);
+  });
+
+  it("executes 'models list' command", async () => {
+    mockExecFileSuccess("gpt-4o\nclaude-sonnet-4-20250514");
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-2", { command: "models list" });
+
+    expect(result.content[0].text).toContain("gpt-4o");
+    expect(result.details.exitCode).toBe(0);
+  });
+
+  it("executes 'route add' with positional args", async () => {
+    mockExecFileSuccess("Route added: fast → openai:gpt-4o-mini");
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-3", {
+      command: "route add fast openai:gpt-4o-mini",
+    });
+
+    expect(result.details.exitCode).toBe(0);
+    const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[1]).toContain("route");
+    expect(call[1]).toContain("add");
+    expect(call[1]).toContain("fast");
+    expect(call[1]).toContain("openai:gpt-4o-mini");
+  });
+
+  it("executes 'route add' with --strategy flag", async () => {
+    mockExecFileSuccess("Route added");
+    const tool = createBitrouterTool(state, stateDirRef);
+    await tool.execute("call-4", {
+      command:
+        "route add research openai:o3 anthropic:claude-opus-4-20250514 --strategy load_balance",
+    });
+
+    const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[1]).toContain("--strategy");
+    expect(call[1]).toContain("load_balance");
+  });
+
+  it("executes 'route rm' command", async () => {
+    mockExecFileSuccess("Route removed: fast");
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-5", { command: "route rm fast" });
+    expect(result.details.exitCode).toBe(0);
+  });
+
+  it("executes 'wallet list' command", async () => {
+    mockExecFileSuccess("default (active)");
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-6", { command: "wallet list" });
+    expect(result.details.exitCode).toBe(0);
+  });
+
+  it("executes 'policy show --id default' command", async () => {
+    mockExecFileSuccess('{"name": "default"}');
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-7", {
+      command: "policy show --id default",
+    });
+    expect(result.details.exitCode).toBe(0);
+  });
+
+  it("strips leading 'bitrouter' from command", async () => {
+    mockExecFileSuccess("ok");
+    const tool = createBitrouterTool(state, stateDirRef);
+    await tool.execute("call-8", { command: "bitrouter status" });
+
+    const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    // Should NOT pass "bitrouter" as an arg — only "status".
+    expect(call[1]).toEqual(["--home-dir", "/tmp/bitrouter-test", "status"]);
+  });
+
+  // ── Blocked commands ─────────────────────────────────────────────
+
+  it("rejects 'wallet create' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-1", {
+      command: "wallet create --name evil",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(result.details.exitCode).toBe(1);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'key create' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-2", {
+      command: "key create --name test --wallet default",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'auth login' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-3", {
+      command: "auth login",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'serve' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-4", { command: "serve" });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'init' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-5", { command: "init" });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'policy create' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-6", {
+      command: "policy create --name evil",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("rejects 'tools discover' as blocked", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-block-7", {
+      command: "tools discover github",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  it("rejects empty command", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-edge-1", { command: "" });
+
+    expect(result.content[0].text).toContain("empty command");
+    expect(result.details.exitCode).toBe(1);
+  });
+
+  it("rejects whitespace-only command", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-edge-2", { command: "   " });
+
+    expect(result.content[0].text).toContain("empty command");
+    expect(result.details.exitCode).toBe(1);
+  });
+
+  it("handles CLI failure gracefully", async () => {
+    mockExecFileFailure("error: unknown model", 1);
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-fail-1", {
+      command: "route rm nonexistent",
+    });
+
+    expect(result.content[0].text).toContain("error: unknown model");
+    expect(result.details.exitCode).toBe(1);
+  });
+
+  it("handles quoted arguments", async () => {
+    mockExecFileSuccess("ok");
+    const tool = createBitrouterTool(state, stateDirRef);
+    await tool.execute("call-quote-1", {
+      command: 'wallet info --wallet "my wallet"',
+    });
+
+    const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(call[1]).toContain("my wallet");
+  });
+});

--- a/tests/bitrouter-tool.test.ts
+++ b/tests/bitrouter-tool.test.ts
@@ -1,23 +1,18 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /**
  * Tests for the unified `bitrouter` agent tool.
  *
- * Tests focus on:
- * - Command allowlist validation
- * - Tokenization of command strings
- * - Rejection of blocked commands
- * - Successful dispatch (mocked binary execution)
+ * The `install` subcommand is owned by the separate `bitrouter_install`
+ * tool (see bitrouter-install-tool.test.ts).
  */
 
-// Mock child_process before importing.
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
 }));
 
-// Mock binary resolution.
 vi.mock("../src/binary.js", () => ({
-  resolveBinaryPath: vi.fn(() => Promise.resolve("/usr/local/bin/bitrouter")),
+  findSystemBinary: vi.fn(() => "/usr/local/bin/bitrouter"),
 }));
 
 import { execFile } from "node:child_process";
@@ -25,9 +20,8 @@ import {
   createBitrouterTool,
   ALLOWED_COMMANDS_DESCRIPTION,
 } from "../src/bitrouter-tool.js";
+import { findSystemBinary } from "../src/binary.js";
 import type { BitrouterState } from "../src/types.js";
-
-// ── Helpers ──────────────────────────────────────────────────────────
 
 function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
   return {
@@ -72,6 +66,9 @@ describe("bitrouter tool", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    (findSystemBinary as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      "/usr/local/bin/bitrouter",
+    );
   });
 
   it("creates a tool with correct name and description", () => {
@@ -81,7 +78,8 @@ describe("bitrouter tool", () => {
     expect(tool.label).toBe("BitRouter CLI");
   });
 
-  it("exports ALLOWED_COMMANDS_DESCRIPTION", () => {
+  it("does not include install in the mono tool allowlist", () => {
+    expect(ALLOWED_COMMANDS_DESCRIPTION).not.toContain("bitrouter install");
     expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter status");
     expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter models list");
     expect(ALLOWED_COMMANDS_DESCRIPTION).toContain("bitrouter route add");
@@ -101,9 +99,9 @@ describe("bitrouter tool", () => {
     });
     expect(result.details.exitCode).toBe(0);
 
-    // Verify binary was called with --home-dir and the command.
     const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
       .calls[0];
+    expect(call[0]).toBe("/usr/local/bin/bitrouter");
     expect(call[1]).toEqual(["--home-dir", "/tmp/bitrouter-test", "status"]);
   });
 
@@ -176,8 +174,34 @@ describe("bitrouter tool", () => {
 
     const call = (execFile as unknown as ReturnType<typeof vi.fn>).mock
       .calls[0];
-    // Should NOT pass "bitrouter" as an arg — only "status".
     expect(call[1]).toEqual(["--home-dir", "/tmp/bitrouter-test", "status"]);
+  });
+
+  // ── install is not handled here ──────────────────────────────────
+
+  it("rejects 'install' (handled by the separate install tool)", async () => {
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-no-install", {
+      command: "install",
+    });
+
+    expect(result.content[0].text).toContain("not allowed");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  // ── Missing system binary ────────────────────────────────────────
+
+  it("returns an instructive error when system binary is missing", async () => {
+    (findSystemBinary as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      null,
+    );
+    const tool = createBitrouterTool(state, stateDirRef);
+    const result = await tool.execute("call-missing-1", { command: "status" });
+
+    expect(execFile).not.toHaveBeenCalled();
+    expect(result.details.exitCode).toBe(127);
+    expect(result.content[0].text).toContain("not found on $PATH");
+    expect(result.content[0].text).toContain("bitrouter_install");
   });
 
   // ── Blocked commands ─────────────────────────────────────────────

--- a/tests/discovery.test.ts
+++ b/tests/discovery.test.ts
@@ -15,7 +15,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };

--- a/tests/http-routes.test.ts
+++ b/tests/http-routes.test.ts
@@ -18,7 +18,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: "test-api-token",
-    adminToken: "test-admin-token",
     onboardingState: null,
     ...overrides,
   };
@@ -63,7 +62,9 @@ describe("registerHttpRoutes", () => {
     registerHttpRoutes(api, state);
 
     const mock = api.registerHttpRoute as ReturnType<typeof vi.fn>;
-    const paths = mock.mock.calls.map((c: unknown[]) => (c[0] as { path: string }).path);
+    const paths = mock.mock.calls.map(
+      (c: unknown[]) => (c[0] as { path: string }).path,
+    );
     expect(paths).toContain("/bitrouter/status");
   });
 
@@ -74,7 +75,9 @@ describe("registerHttpRoutes", () => {
     registerHttpRoutes(api, state);
 
     const mock = api.registerHttpRoute as ReturnType<typeof vi.fn>;
-    const paths = mock.mock.calls.map((c: unknown[]) => (c[0] as { path: string }).path);
+    const paths = mock.mock.calls.map(
+      (c: unknown[]) => (c[0] as { path: string }).path,
+    );
     expect(paths).toContain("/bitrouter/metrics");
   });
 
@@ -85,7 +88,9 @@ describe("registerHttpRoutes", () => {
     registerHttpRoutes(api, state);
 
     const mock = api.registerHttpRoute as ReturnType<typeof vi.fn>;
-    const paths = mock.mock.calls.map((c: unknown[]) => (c[0] as { path: string }).path);
+    const paths = mock.mock.calls.map(
+      (c: unknown[]) => (c[0] as { path: string }).path,
+    );
     expect(paths).toContain("/bitrouter/routes");
   });
 
@@ -96,7 +101,9 @@ describe("registerHttpRoutes", () => {
     registerHttpRoutes(api, state);
 
     const mock = api.registerHttpRoute as ReturnType<typeof vi.fn>;
-    const paths = mock.mock.calls.map((c: unknown[]) => (c[0] as { path: string }).path);
+    const paths = mock.mock.calls.map(
+      (c: unknown[]) => (c[0] as { path: string }).path,
+    );
     expect(paths).toContain("/bitrouter/models");
   });
 
@@ -132,7 +139,7 @@ describe("registerHttpRoutes", () => {
 
     const mock = api.registerHttpRoute as ReturnType<typeof vi.fn>;
     const statusRoute = mock.mock.calls.find(
-      (c: unknown[]) => (c[0] as { path: string }).path === "/bitrouter/status"
+      (c: unknown[]) => (c[0] as { path: string }).path === "/bitrouter/status",
     );
     const handler = (statusRoute![0] as { handler: Function }).handler;
 
@@ -145,7 +152,7 @@ describe("registerHttpRoutes", () => {
 
     expect(res.writeHead).toHaveBeenCalledWith(503, expect.any(Object));
     expect(res.end).toHaveBeenCalledWith(
-      expect.stringContaining("not healthy")
+      expect.stringContaining("not healthy"),
     );
   });
 });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -146,7 +146,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 
@@ -167,7 +166,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 
@@ -193,7 +191,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 
@@ -227,7 +224,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 
@@ -261,7 +257,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 
@@ -288,7 +283,6 @@ describe("Integration: plugin against live BitRouter", () => {
         homeDir: "/tmp/test",
         metrics: null,
         apiToken: null,
-        adminToken: null,
         onboardingState: null,
       };
 

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createMcpToolsBridge } from "../src/mcp-tools.js";
+import type {
+  BitrouterState,
+  OpenClawPluginApi,
+  ToolInfo,
+} from "../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
+  return {
+    process: null,
+    healthy: true,
+    baseUrl: "http://127.0.0.1:8787",
+    knownRoutes: [],
+    knownModels: [],
+    knownAgents: [],
+    knownTools: [],
+    knownSkills: [],
+    healthCheckTimer: null,
+    homeDir: "/tmp/bitrouter-test",
+    metrics: null,
+    apiToken: null,
+    adminToken: null,
+    onboardingState: null,
+    ...overrides,
+  };
+}
+
+function createMockApi() {
+  return {
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerTool: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    on: vi.fn(),
+    pluginConfig: {},
+    config: { agents: { defaults: { model: { primary: "default" } } } },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  } as unknown as OpenClawPluginApi;
+}
+
+function makeTool(id: string, provider = "mcp-server"): ToolInfo {
+  return {
+    id,
+    name: id,
+    provider,
+    description: `Tool ${id}`,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("MCP Tools Bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers MCP tools from state.knownTools", () => {
+    const tools = [makeTool("read_file"), makeTool("list_dir")];
+    const state = createMockState({ knownTools: tools });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    expect(api.registerTool).toHaveBeenCalledTimes(2);
+    expect(bridge.registeredToolNames.has("bitrouter_read_file")).toBe(true);
+    expect(bridge.registeredToolNames.has("bitrouter_list_dir")).toBe(true);
+  });
+
+  it("skips skill entries (provider === 'skill')", () => {
+    const tools = [
+      makeTool("read_file", "mcp-server"),
+      makeTool("my_skill", "skill"),
+    ];
+    const state = createMockState({ knownTools: tools });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    expect(api.registerTool).toHaveBeenCalledTimes(1);
+    expect(bridge.registeredToolNames.has("bitrouter_my_skill")).toBe(false);
+  });
+
+  it("does not re-register already registered tools", () => {
+    const tools = [makeTool("read_file")];
+    const state = createMockState({ knownTools: tools });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+    bridge.registerInitialTools(); // second call
+
+    expect(api.registerTool).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers new tools on refresh", () => {
+    const state = createMockState({ knownTools: [makeTool("read_file")] });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+    expect(api.registerTool).toHaveBeenCalledTimes(1);
+
+    // Add a new tool.
+    state.knownTools.push(makeTool("write_file"));
+    bridge.refresh();
+
+    expect(api.registerTool).toHaveBeenCalledTimes(2);
+    expect(bridge.registeredToolNames.has("bitrouter_write_file")).toBe(true);
+  });
+
+  it("removes stale tool names on refresh", () => {
+    const state = createMockState({
+      knownTools: [makeTool("read_file"), makeTool("list_dir")],
+    });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+    expect(bridge.registeredToolNames.size).toBe(2);
+
+    // Remove list_dir from state.
+    state.knownTools = [makeTool("read_file")];
+    bridge.refresh();
+
+    expect(bridge.registeredToolNames.has("bitrouter_list_dir")).toBe(false);
+    expect(bridge.registeredToolNames.has("bitrouter_read_file")).toBe(true);
+  });
+
+  it("registers tools as optional", () => {
+    const state = createMockState({ knownTools: [makeTool("read_file")] });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    const opts = (api.registerTool as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(opts.optional).toBe(true);
+  });
+
+  it("namespaces tool names with bitrouter_ prefix", () => {
+    const state = createMockState({ knownTools: [makeTool("read_file")] });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    const opts = (api.registerTool as ReturnType<typeof vi.fn>).mock
+      .calls[0][1];
+    expect(opts.name).toBe("bitrouter_read_file");
+  });
+
+  it("handles empty tool list gracefully", () => {
+    const state = createMockState({ knownTools: [] });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    expect(api.registerTool).not.toHaveBeenCalled();
+    expect(bridge.registeredToolNames.size).toBe(0);
+  });
+
+  it("replaces special chars in tool names", () => {
+    const state = createMockState({
+      knownTools: [makeTool("some-server/read.file")],
+    });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    expect(
+      bridge.registeredToolNames.has("bitrouter_some_server_read_file"),
+    ).toBe(true);
+  });
+
+  it("logs warning on registration failure", () => {
+    const state = createMockState({ knownTools: [makeTool("read_file")] });
+    const api = createMockApi();
+    (api.registerTool as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("registration failed");
+    });
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    expect(api.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to register MCP tool"),
+    );
+  });
+});
+
+describe("MCP proxy tool execution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("proxy tool returns error when BitRouter is unhealthy", async () => {
+    const state = createMockState({
+      healthy: false,
+      knownTools: [makeTool("read_file")],
+    });
+    const api = createMockApi();
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    // Get the registered tool.
+    const registeredTool = (api.registerTool as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const result = await registeredTool.execute("call-1", {});
+
+    expect(result.content[0].text).toContain("not healthy");
+    expect(result.details.isError).toBe(true);
+  });
+
+  it("proxy tool calls MCP gateway on execution", async () => {
+    const state = createMockState({
+      healthy: true,
+      knownTools: [makeTool("read_file")],
+    });
+    const api = createMockApi();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: {
+              content: [{ type: "text", text: "file contents here" }],
+              isError: false,
+            },
+          }),
+      }),
+    );
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    const registeredTool = (api.registerTool as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const result = await registeredTool.execute("call-2", {
+      arguments: { path: "/test.txt" },
+    });
+
+    expect(result.content[0].text).toBe("file contents here");
+    expect(result.details.isError).toBe(false);
+
+    // Verify the MCP gateway was called correctly.
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[0]).toBe("http://127.0.0.1:8787/mcp");
+    const body = JSON.parse(fetchCall[1].body);
+    expect(body.method).toBe("tools/call");
+    expect(body.params.name).toBe("read_file");
+    expect(body.params.arguments).toEqual({ path: "/test.txt" });
+  });
+
+  it("proxy tool handles MCP gateway errors", async () => {
+    const state = createMockState({
+      healthy: true,
+      knownTools: [makeTool("read_file")],
+    });
+    const api = createMockApi();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    const bridge = createMcpToolsBridge(api, state);
+    bridge.registerInitialTools();
+
+    const registeredTool = (api.registerTool as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    const result = await registeredTool.execute("call-3", {});
+
+    expect(result.content[0].text).toContain("MCP gateway error");
+    expect(result.details.isError).toBe(true);
+  });
+});

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -22,7 +22,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };

--- a/tests/prompt-context.test.ts
+++ b/tests/prompt-context.test.ts
@@ -51,12 +51,12 @@ function createMockApi() {
 function getHookHandler(api: OpenClawPluginApi) {
   const onMock = api.on as ReturnType<typeof vi.fn>;
   const call = onMock.mock.calls.find(
-    (c: unknown[]) => c[0] === "before_prompt_build"
+    (c: unknown[]) => c[0] === "before_prompt_build",
   );
   expect(call).toBeTruthy();
   return call![1] as (
     event: { prompt: string },
-    ctx: { agentId?: string }
+    ctx: { agentId?: string },
   ) => { prependContext?: string; appendSystemContext?: string } | void;
 }
 
@@ -73,11 +73,11 @@ describe("registerPromptContext", () => {
     const onMock = api.on as ReturnType<typeof vi.fn>;
     expect(onMock).toHaveBeenCalledWith(
       "before_prompt_build",
-      expect.any(Function)
+      expect.any(Function),
     );
   });
 
-  it("returns static appendSystemContext with CLI reference", () => {
+  it("returns static appendSystemContext with tool reference", () => {
     const api = createMockApi();
     const config: BitrouterPluginConfig = { mode: "byok" };
     const state = createMockState();
@@ -87,8 +87,8 @@ describe("registerPromptContext", () => {
     const result = handler({ prompt: "hello" }, {});
 
     expect(result).toBeTruthy();
-    expect(result!.appendSystemContext).toContain("openclaw bitrouter status");
-    expect(result!.appendSystemContext).toContain("/bitrouter skill");
+    expect(result!.appendSystemContext).toContain("bitrouter");
+    expect(result!.appendSystemContext).toContain("Available tool commands");
   });
 
   it("omits healthy tag when BitRouter is down", () => {
@@ -113,7 +113,11 @@ describe("registerPromptContext", () => {
       healthy: true,
       knownRoutes: [
         { model: "gpt-4o", provider: "openai", protocol: "openai" },
-        { model: "claude-3-5-sonnet", provider: "anthropic", protocol: "anthropic" },
+        {
+          model: "claude-3-5-sonnet",
+          provider: "anthropic",
+          protocol: "anthropic",
+        },
       ],
     });
 

--- a/tests/prompt-context.test.ts
+++ b/tests/prompt-context.test.ts
@@ -22,7 +22,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -19,7 +19,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };
@@ -54,7 +53,8 @@ describe("registerBitrouterProvider", () => {
 
     registerBitrouterProvider(api, config, state);
 
-    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     expect(call.id).toBe("bitrouter");
     expect(call.label).toBe("BitRouter");
   });
@@ -66,7 +66,8 @@ describe("registerBitrouterProvider", () => {
 
     registerBitrouterProvider(api, config, state);
 
-    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     expect(call.envVars).toContain("BITROUTER_API_KEY");
     expect(call.envVars).toContain("OPENAI_API_KEY");
     expect(call.envVars).toContain("ANTHROPIC_API_KEY");
@@ -80,29 +81,28 @@ describe("registerBitrouterProvider", () => {
 
     registerBitrouterProvider(api, config, state);
 
-    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     expect(call.catalog).toBeTruthy();
     expect(call.catalog.order).toBe("late");
     expect(typeof call.catalog.run).toBe("function");
   });
 
-  it("includes two auth methods with non-interactive support on byok", () => {
+  it("includes auth method with non-interactive support", () => {
     const api = createMockApi();
     const config: BitrouterPluginConfig = {};
     const state = createMockState();
 
     registerBitrouterProvider(api, config, state);
 
-    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(call.auth).toHaveLength(2);
+    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(call.auth).toHaveLength(1);
 
     const byok = call.auth.find((a: { id: string }) => a.id === "byok");
     expect(byok).toBeTruthy();
     expect(typeof byok.run).toBe("function");
     expect(typeof byok.runNonInteractive).toBe("function");
-
-    const cloud = call.auth.find((a: { id: string }) => a.id === "cloud");
-    expect(cloud).toBeTruthy();
   });
 
   it("includes formatApiKey handler", () => {
@@ -112,11 +112,15 @@ describe("registerBitrouterProvider", () => {
 
     registerBitrouterProvider(api, config, state);
 
-    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const call = (api.registerProvider as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
     expect(typeof call.formatApiKey).toBe("function");
 
     // formatApiKey extracts the key from an api_key credential.
-    const result = call.formatApiKey({ type: "api_key", key: "test-jwt-token" });
+    const result = call.formatApiKey({
+      type: "api_key",
+      key: "test-jwt-token",
+    });
     expect(result).toBe("test-jwt-token");
   });
 });

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -24,7 +24,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     ...overrides,
   };
 }

--- a/tests/service.test.ts
+++ b/tests/service.test.ts
@@ -45,7 +45,7 @@ vi.mock("../src/metrics.js", () => ({
 }));
 
 vi.mock("../src/auth.js", () => ({
-  ensureAuth: vi.fn(() => ({ apiToken: "mock-api-jwt", adminToken: "mock-admin-jwt" })),
+  ensureAuth: vi.fn(() => ({ apiToken: "mock-api-jwt" })),
 }));
 
 vi.mock("../src/discovery.js", () => ({
@@ -82,7 +82,6 @@ function createMockState(): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
   };
 }
@@ -140,7 +139,7 @@ describe("registerBitrouterService", () => {
         id: "bitrouter",
         start: expect.any(Function),
         stop: expect.any(Function),
-      })
+      }),
     );
   });
 
@@ -164,7 +163,7 @@ describe("registerBitrouterService", () => {
       expect.objectContaining({
         stdio: ["ignore", "pipe", "pipe"],
         detached: false,
-      })
+      }),
     );
     expect(state.process).toBe(mockChild);
   });
@@ -197,7 +196,7 @@ describe("registerBitrouterService", () => {
 
   it("throws when binary resolution fails", async () => {
     vi.mocked(resolveBinaryPath).mockRejectedValue(
-      new Error("BitRouter binary not found.")
+      new Error("BitRouter binary not found."),
     );
 
     const api = createMockApi();
@@ -206,6 +205,8 @@ describe("registerBitrouterService", () => {
     registerBitrouterService(api, {}, state, stateDirRef);
 
     const serviceOpts = vi.mocked(api.registerService).mock.calls[0][0];
-    await expect(serviceOpts.start(mockCtx)).rejects.toThrow("BitRouter binary not found.");
+    await expect(serviceOpts.start(mockCtx)).rejects.toThrow(
+      "BitRouter binary not found.",
+    );
   });
 });

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -22,7 +22,6 @@ function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
     homeDir: "/tmp/bitrouter-test",
     metrics: null,
     apiToken: null,
-    adminToken: null,
     onboardingState: null,
     ...overrides,
   };

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fetchMetrics,
+  summarizeMetrics,
+  formatUsageText,
+} from "../src/usage.js";
+import type { BitrouterState, MetricsResponse } from "../src/types.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function createMockState(overrides?: Partial<BitrouterState>): BitrouterState {
+  return {
+    process: null,
+    healthy: true,
+    baseUrl: "http://127.0.0.1:8787",
+    knownRoutes: [],
+    knownModels: [],
+    knownAgents: [],
+    knownTools: [],
+    knownSkills: [],
+    healthCheckTimer: null,
+    homeDir: "/tmp/bitrouter-test",
+    metrics: null,
+    apiToken: null,
+    adminToken: null,
+    onboardingState: null,
+    ...overrides,
+  };
+}
+
+const SAMPLE_METRICS: MetricsResponse = {
+  uptime_seconds: 3661,
+  routes: {
+    fast: {
+      total_requests: 42,
+      total_errors: 2,
+      latency_p50_ms: 150,
+      latency_p99_ms: 800,
+      avg_input_tokens: 100,
+      avg_output_tokens: 500,
+      last_used: "2025-01-15T10:30:00Z",
+      by_endpoint: {
+        "openai:gpt-4o-mini": {
+          total_requests: 42,
+          total_errors: 2,
+          latency_p50_ms: 150,
+          latency_p99_ms: 800,
+        },
+      },
+    },
+    research: {
+      total_requests: 5,
+      total_errors: 0,
+      latency_p50_ms: 2000,
+      latency_p99_ms: 5000,
+      avg_input_tokens: 500,
+      avg_output_tokens: 2000,
+      last_used: "2025-01-15T09:00:00Z",
+      by_endpoint: {},
+    },
+  },
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("fetchMetrics", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches and caches metrics on success", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(SAMPLE_METRICS),
+      }),
+    );
+
+    const state = createMockState();
+    const result = await fetchMetrics(state);
+
+    expect(result).toEqual(SAMPLE_METRICS);
+    expect(state.metrics).toEqual(SAMPLE_METRICS);
+  });
+
+  it("returns null when BitRouter is unhealthy", async () => {
+    const state = createMockState({ healthy: false });
+    const result = await fetchMetrics(state);
+    expect(result).toBeNull();
+  });
+
+  it("returns null on fetch failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connection refused")),
+    );
+
+    const state = createMockState();
+    const result = await fetchMetrics(state);
+    expect(result).toBeNull();
+  });
+
+  it("returns null on non-200 response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+
+    const state = createMockState();
+    const result = await fetchMetrics(state);
+    expect(result).toBeNull();
+  });
+
+  it("includes auth header when apiToken is set", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(SAMPLE_METRICS),
+      }),
+    );
+
+    const state = createMockState({ apiToken: "test-jwt" });
+    await fetchMetrics(state);
+
+    const fetchCall = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(fetchCall[1].headers).toEqual({
+      Authorization: "Bearer test-jwt",
+    });
+  });
+});
+
+describe("summarizeMetrics", () => {
+  it("converts metrics into structured summary", () => {
+    const summary = summarizeMetrics(SAMPLE_METRICS);
+
+    expect(summary.uptime).toBe(3661);
+    expect(summary.routes).toHaveLength(2);
+
+    const fast = summary.routes.find((r) => r.route === "fast");
+    expect(fast).toBeDefined();
+    expect(fast?.requests).toBe(42);
+    expect(fast?.errors).toBe(2);
+    expect(fast?.p50Ms).toBe(150);
+  });
+
+  it("handles empty routes", () => {
+    const summary = summarizeMetrics({
+      uptime_seconds: 100,
+      routes: {},
+    });
+
+    expect(summary.routes).toHaveLength(0);
+  });
+});
+
+describe("formatUsageText", () => {
+  it("formats metrics as readable text", () => {
+    const text = formatUsageText(SAMPLE_METRICS);
+
+    expect(text).toContain("BitRouter Uptime: 61m 1s");
+    expect(text).toContain("Route Metrics:");
+    expect(text).toContain("fast:");
+    expect(text).toContain("42 req");
+    expect(text).toContain("research:");
+  });
+
+  it("handles empty routes", () => {
+    const text = formatUsageText({
+      uptime_seconds: 0,
+      routes: {},
+    });
+
+    expect(text).toContain("No route metrics recorded yet.");
+  });
+});


### PR DESCRIPTION
## Summary

Expands bitrouter-openclaw from a provider-only plugin to a hybrid-capability plugin with tool integration, MCP bridge, usage tracking, and ClawHub-ready manifest.

## Changes

### Phase 1 — Manifest & ClawHub readiness
- Enriched `openclaw.plugin.json` with `modelSupport`, `activation`, `setup`, and `contracts` fields
- Added `openclaw.compat` and `openclaw.build` to `package.json`

### Phase 2 — Unified `bitrouter` agent tool
- New `src/bitrouter-tool.ts`: one tool agents can call with 15 allowlisted safe CLI commands
- Covers: status, models list, tools list/status, route list/add/rm, agents list/check, auth status, wallet list/info, key list, policy list/show
- Input validation, command tokenization, and sandboxed execution

### Phase 3 — MCP tools bridge
- New `src/mcp-tools.ts`: discovers BitRouter `/v1/tools`, registers as optional OpenClaw tools
- Proxies execution via JSON-RPC to BitRouter `/mcp` endpoint
- Auto-refreshes on health check cycles

### Phase 4 — Usage/spend tracking
- New `src/usage.ts`: fetches `/v1/metrics`, formats usage snapshots
- Wired into provider via `resolveUsageAuth` and `fetchUsageSnapshot` hooks

### Phase 5 — Enhanced provider hooks
- Added `buildMissingAuthMessage` for BitRouter-specific auth guidance
- Updated prompt context to reference the `bitrouter` tool instead of raw CLI

## Testing
- 43 new unit tests across 3 new test files
- All 116 unit tests pass
- TypeScript compiles cleanly, build succeeds

## Stats
14 files changed, 1838 insertions, 127 deletions (8 modified, 6 new)